### PR TITLE
IP-002: MDAST

### DIFF
--- a/definition/Improvement-proposals/IP-002.MD
+++ b/definition/Improvement-proposals/IP-002.MD
@@ -1,6 +1,501 @@
-## IP-002 (DRAFT): Upgrade prose section to use MDAST (Markdown Abstract Syntax Tree)
+# IP-002 (DRAFT): Upgrade prose section to use MDAST (Markdown Abstract Syntax Tree)
 
-This proposal is to upgrade the prose section of the protocol to use MDAST (Markdown Abstract Syntax Tree) instead of the current JSON structure.
+## Executive Summary
 
-This will allow for a more powerful and flexible prose section, and will also allow for the prose section to be rendered in a more user-friendly way.
+This proposal recommends using Markdown and [MDAST (Markdown Abstract Syntax Tree)](https://github.com/syntax-tree/mdast) for representing agreement content instead of [Blocknote.js JSON](https://www.blocknotejs.org/docs/editor-basics/document-structure). This approach enables structured, portable representation of agreements with support for dynamic elements such as variables and addresses while ensuring cross-system compatibility.
 
+## Overview
+
+### Problem Statement
+
+Blocknote.js JSON is difficult to manipulate and transport between systems due to its proprietary structure, creating challenges when storing it inside an agreement protocol.
+
+### Proposed Solution
+
+Shift to Markdown and MDAST (Markdown Abstract Syntax Tree) to enable:
+
+- Structured, consistent representation of agreement content
+- Cross-system compatibility
+- Easy integration of dynamic elements (variables, addresses)
+- Dedicated parsers and renderers
+
+## MDAST: Foundation for Document Processing
+
+[MDAST](https://github.com/syntax-tree/mdast) provides a standardized tree structure for Markdown content that enables interoperability within the [Unist](https://github.com/syntax-tree/unist) ecosystem. This foundation offers:
+
+- **Custom Nodes**: Support for dynamic content like variables and addresses
+- **Extensibility**: Plugin-based architecture for transformations and validation
+- **Structured Data**: Consistent format improves maintainability and type safety
+- **Transformation Pipeline**: Efficient conversion between formats (Markdown ↔ MDAST ↔ HTML/React)
+
+## Plain Markdown vs. MDAST
+
+| Aspect | Plain Markdown | MDAST |
+| --- | --- | --- |
+| **Simplicity** | ✅ Simpler syntax, familiar to non-technical users | ⚠️ Slightly more complex |
+| **Custom Elements** | ❌ No native support for custom elements | ✅ First-class support for custom nodes |
+| **Validation** | ❌ Limited structural validation | ✅ Type-safe structure ensures protocol integrity |
+| **Programmability** | ❌ Harder to manipulate programmatically | ✅ Easy programmatic updates |
+| **Type Safety** | ❌ Error-prone text processing | ✅ Typed structure prevents errors |
+| **Human Readability** | ✅ Directly readable and editable as text | ❌ Requires tooling to read/edit comfortably |
+| **Storage Efficiency** | ✅ More compact representation | ❌ More verbose JSON structure |
+| **Structural Precision** | ❌ Can be ambiguous in some cases | ✅ Precisely represents document structure |
+
+**Recommendation**: Use MDAST for agreements requiring variable substitution, address formatting, and structural validation. Plain Markdown may suffice for simple agreements without dynamic content.
+
+## Protocol Structure
+
+```tsx
+interface AgreementProtocol {
+  version: string;
+  variables: VariableDefinition[];
+  content_mdast: MDAST;  // The MDAST root node - can be converted to/from Markdown
+}
+
+interface VariableDefinition {
+  name: string;
+  type: "string" | "number" | "address" | "dateTime";
+  default?: string;
+  validation?: ValidationRules;
+}
+
+interface ValidationRules {
+  required?: boolean;
+  pattern?: string;
+  minLength?: number;
+  maxLength?: number;
+  message?: string;
+}
+```
+
+Validation rules follow [MDN's Form Validation](https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Form_validation) standards, ensuring compatibility with web form validation.
+
+## Custom Node Implementation
+
+### Variable and Address Nodes
+
+```tsx
+// MDAST node for variables
+interface Variable {
+  type: "variable";
+  name: string;
+}
+
+// MDAST node for wallet addresses
+interface Address {
+  type: "address";
+  value: string;
+  display?: "truncated" | "full" | "ens";
+}
+```
+
+## Representation Examples
+
+Agreement content can be stored as MDAST in the protocol and converted to/from Markdown with directives:
+
+> **Note**: support could also be added to go from MDAST to/from BlockNote.js JSON
+> 
+
+### Protocol JSON
+
+```json
+{
+  "version": "1.0",
+  "variables": [
+    {
+      "name": "effectiveDate",
+      "type": "dateTime",
+      "default": "2024-01-01",
+      "validation": {
+        "required": true
+      }
+    },
+    {
+      "name": "recipient",
+      "type": "string",
+      "default": "John Doe",
+      "validation": {
+        "required": true,
+        "minLength": 3
+      }
+    },
+    {
+      "name": "recipientAddress",
+      "type": "address",
+      "default": "0x456...def",
+      "validation": {
+        "pattern": "^0x[a-fA-F0-9]{40}$",
+        "message": "Invalid Ethereum wallet address"
+      }
+    }
+  ],
+  "content_mdast": {
+    "type": "root",
+    "children": [
+      {
+        "type": "heading",
+        "depth": 1,
+        "children": [{ "type": "text", "value": "Grant Agreement" }]
+      },
+      {
+        "type": "paragraph",
+        "children": [
+          { "type": "text", "value": "This Grant Agreement (" },
+          {
+            "type": "strong",
+            "children": [{ "type": "text", "value": "Agreement" }]
+          },
+          { "type": "text", "value": ") is entered into on " },
+          { "type": "variable", "name": "effectiveDate" },
+          { "type": "text", "value": ", (the " },
+          {
+            "type": "strong",
+            "children": [{ "type": "text", "value": "Effective Date" }]
+          },
+          { "type": "text", "value": "), between Ecosystem Name Foundation, a Jurisdiction foundation company (the " },
+          {
+            "type": "strong",
+            "children": [{ "type": "text", "value": "Foundation" }]
+          },
+          { "type": "text", "value": ") with D3 address " },
+          { "type": "address", "value": "0x123f6e75d1BE0ee699C7Eb67594FEbC14ab3AA78", "display": "truncated" },
+          { "type": "text", "value": ", and " },
+          { "type": "variable", "name": "recipient" },
+          { "type": "text", "value": ", an individual with address " },
+          { "type": "variable", "name": "recipientAddress" },
+          { "type": "text", "value": " (" },
+          {
+            "type": "strong",
+            "children": [{ "type": "text", "value": "Grant Recipient" }]
+          },
+          { "type": "text", "value": ")." }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### MDAST <> Markdown with Custom Node Syntax
+
+We extend standard Markdown using the [remark-directive](https://github.com/remarkjs/remark-directive) plugin, which adds support for custom directives in Markdown:
+
+```markdown
+# Grant Agreement
+
+This Grant Agreement (**Agreement**) is entered into on :variable{name='effectiveDate'}, (the **Effective Date**), between Ecosystem Name Foundation, a Jurisdiction foundation company (the **Foundation**) with D3 address :address{value='0x123f6e75d1BE0ee699C7Eb67594FEbC14ab3AA78' display='truncated'}, and :variable{name='recipient'}, an individual with address :variable{name='recipientAddress'} (**Grant Recipient**).
+```
+
+**What is remark-directive?**
+
+Remark-directive is a plugin for the remark Markdown processor that enables a standardized syntax for custom elements within Markdown. It allows for directives like `:variable{name='value'}` which can be transformed into custom nodes during parsing. 
+
+This approach provides:
+
+- Clear, readable syntax in plain text
+- Support for attributes and properties
+- Integration with the established remark ecosystem
+- **Bidirectional conversion** between MDAST and Markdown
+
+### Alternative Approaches Considered
+
+1. **Template Strings** (`{{variableName}}`):
+    - ✅ Simple, familiar from template engines
+    - ❌ Cannot support properties/attributes
+2. **HTML-Like Syntax** (`<variable name="recipient" />`):
+    - ✅ Natural attribute syntax
+    - ❌ Conflicts with Markdown's HTML processing
+3. **Custom Delimiters** (`$variableName$`):
+    - ✅ Can be designed for custom needs
+    - ❌ Requires custom parser implementation
+
+The directive approach balances readability, structural support, and ecosystem integration.
+
+## Workflow
+
+### Reading Protocol
+
+1. Parse Protocol JSON
+2. Extract variable defaults
+3. Process MDAST to desired output
+4. Render with variable values and formatted addresses
+
+### Updating Variables
+
+1. Capture user input
+2. Update protocol with `saveVariableValue`
+3. Re-render with new values
+4. Persist changes when needed
+
+### Complete Workflow Example
+
+> Note: This example uses React, but similar workflows can be implemented with any technology stack.
+> 
+
+```tsx
+import React, { useState } from 'react';
+import { AgreementRenderer, saveVariableValue } from './agreement-utils';
+
+export default function AgreementEditor({ initialProtocol }) {
+  const [protocol, setProtocol] = useState(initialProtocol);
+
+  // Handle variable changes
+  const handleVariableChange = (name, value) => {
+    // Update protocol with new variable value
+    const updatedProtocol = saveVariableValue(protocol, name, value);
+    setProtocol(updatedProtocol);
+  };
+
+  // Handle agreement submission
+  const handleSubmit = () => {
+    // Validate all variables before submission
+    const isValid = protocol.variables.every(variable => {
+      if (variable.validation?.required && !variable.default) {
+        return false;
+      }
+      if (variable.validation?.pattern && variable.default) {
+        const regex = new RegExp(variable.validation.pattern);
+        return regex.test(variable.default);
+      }
+      return true;
+    });
+
+    if (isValid) {
+      // Submit protocol to API/blockchain/storage
+      console.log('Submitting valid protocol', protocol);
+    } else {
+      console.error('Invalid protocol - validation failed');
+    }
+  };
+
+  return (
+    <div className="agreement-editor">
+      <h2>Agreement Editor</h2>
+
+      {/* Render the agreement with editable variables */}
+      <AgreementRenderer
+        protocol={protocol}
+        editable={true}
+        onVariableChange={handleVariableChange}
+      />
+
+      <div className="agreement-actions">
+        <button onClick={handleSubmit}>
+          Submit Agreement
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+## Implementation Examples
+
+> Note: The examples below use React, but the MDAST approach is framework-agnostic. The core concepts (parsing, transformation, and rendering) remain consistent across all implementations.
+> 
+
+### 1. Custom Node Handlers
+
+This example shows how to implement the custom node handlers for variables and addresses:
+
+```tsx
+import { Transformer } from 'unified';
+import { visit } from 'unist-util-visit';
+import remarkDirective from 'remark-directive';
+
+// Setup the directive plugin and our custom handlers
+export function setupCustomNodes() {
+  return [
+    remarkDirective,
+    customNodesHandler
+  ];
+}
+
+// Plugin to convert directive nodes to our custom node types
+function customNodesHandler(): Transformer {
+  return (tree) => {
+    visit(tree, ['textDirective'], (node: any) => {
+      if (node.name === 'variable') {
+        node.type = 'variable';
+        node.name = node.attributes?.name;
+        delete node.attributes;
+      }
+
+      if (node.name === 'address') {
+        node.type = 'address';
+        node.value = node.attributes?.value;
+        node.display = node.attributes?.display || 'truncated';
+        delete node.attributes;
+      }
+    });
+    return tree;
+  };
+}
+```
+
+### 2. Variable Management
+
+This plugin adds values to variable nodes and provides a utility to update variable values:
+
+```tsx
+// Plugin to add values to variable nodes during rendering
+export function variableValuesPlugin(variables = {}) {
+  return (tree) => {
+    visit(tree, 'variable', (node: any) => {
+      // Add a value property from the variables map
+      node.value = variables[node.name] || '';
+    });
+    return tree;
+  };
+}
+
+// Function to save a new variable value back to the protocol object
+export function saveVariableValue(protocol, variableName, newValue) {
+  // Create a deep copy to avoid mutating the original
+  const updatedProtocol = JSON.parse(JSON.stringify(protocol));
+
+  // Update the default value in the variables array
+  const variableIndex = updatedProtocol.variables.findIndex(
+    (v) => v.name === variableName
+  );
+
+  if (variableIndex !== -1) {
+    updatedProtocol.variables[variableIndex].default = newValue;
+  }
+
+  return updatedProtocol;
+}
+```
+
+### 3. Rendering Components
+
+These React components handle the display of variables and addresses:
+
+```tsx
+// Variable component for rendering
+const VariableComponent = ({ name, value, editable = false, onEdit }) => {
+  if (!editable) {
+    return <span className="variable" data-name={name}>{value || `[${name}]`}</span>;
+  }
+
+  return (
+    <input
+      className="variable-input"
+      data-name={name}
+      value={value || ''}
+      onChange={(e) => onEdit && onEdit(name, e.target.value)}
+    />
+  );
+};
+
+// Address component for rendering
+const AddressComponent = ({ value, display = "truncated" }) => {
+  // Format address based on display mode
+  const formatAddress = () => {
+    switch (display) {
+      case "full":
+        return value;
+      case "ens":
+        return value === "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+          ? "vitalik.eth"
+          : `${value.slice(0, 6)}...${value.slice(-4)}`;
+      case "truncated":
+      default:
+        return `${value.slice(0, 6)}...${value.slice(-4)}`;
+    }
+  };
+
+  return (
+    <span className={`address address-${display}`} title={value}>
+      {formatAddress()}
+    </span>
+  );
+};
+```
+
+### 4. Complete Agreement Renderer
+
+This example shows how to implement a complete agreement renderer:
+
+```tsx
+function AgreementRenderer({ protocol, editable = false, onVariableChange }) {
+  // Extract variables into a flat map
+  const variableValues = protocol.variables.reduce((acc, v) => {
+    acc[v.name] = v.default || '';
+    return acc;
+  }, {});
+
+  // Handle variable editing
+  const handleVariableEdit = (name, value) => {
+    if (onVariableChange) {
+      onVariableChange(name, value);
+    }
+  };
+
+  // Create processor pipeline
+  const processor = unified()
+    .use(remarkParse)
+    .use(setupCustomNodes)
+    .use(variableValuesPlugin, variableValues)
+    .use(remarkRehype, {
+      handlers: {
+        // Convert custom nodes to HTML
+        variable: (h, node) => {
+          return h(node, 'variable', {
+            name: node.name,
+            value: node.value,
+            editable,
+            onEdit: handleVariableEdit
+          });
+        },
+        address: (h, node) => {
+          return h(node, 'address', {
+            value: node.value,
+            display: node.display
+          });
+        }
+      }
+    })
+    .use(rehypeReact, {
+      createElement: React.createElement,
+      components: {
+        variable: VariableComponent,
+        address: AddressComponent
+      }
+    });
+
+  // Process content - handles both string markdown or MDAST
+  const content = typeof protocol.content === 'string'
+    ? processor.processSync(protocol.content).result
+    : processor.runSync(protocol.content);
+
+  return <div className="agreement-document">{content}</div>;
+}
+```
+
+## Security Considerations
+
+- Validate variables against defined rules
+- Sanitize user inputs to prevent XSS attacks
+- Ensure directive parsing doesn't introduce security vulnerabilities
+
+## Development Resources
+
+### Core Libraries
+
+- [unified](https://unifiedjs.com/) - Processing content with plugins
+- [remark](https://github.com/remarkjs/remark) - Markdown processor
+- [rehype](https://github.com/rehypejs/rehype) - HTML processor
+
+### Tools
+
+- [mdast-util-from-markdown](https://github.com/syntax-tree/mdast-util-from-markdown)
+- [unist-util-visit](https://github.com/syntax-tree/unist-util-visit)
+- [AJV](https://ajv.js.org/) - JSON Schema validator
+
+### Framework-Specific Implementations
+
+- React: [rehype-react](https://github.com/rehypejs/rehype-react), [react-markdown](https://github.com/remarkjs/react-markdown)
+- Vue: [vue-remark](https://github.com/mactavishz/vue-remark)
+- Angular: Can be implemented using unified with custom rendering
+- Server-Side: Can use [remark-html](https://github.com/remarkjs/remark-html) for static HTML generation


### PR DESCRIPTION
This proposal recommends using Markdown and [MDAST (Markdown Abstract Syntax Tree)](https://github.com/syntax-tree/mdast) for representing agreement content instead of [Blocknote.js JSON](https://www.blocknotejs.org/docs/editor-basics/document-structure). This approach enables structured, portable representation of agreements with support for dynamic elements such as variables and addresses while ensuring cross-system compatibility.