### PR TITLE
(1/3) IP-005 for core and EVM profile split

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The protocol consists of five core components:
 - ✅ **[IP-002](./improvement-proposals/IP-002.md)**: MDAST Content Representation
 - 🚧 **[IP-003](https://github.com/ConsenSysMesh/agreements-protocol/pull/16)**: Proofs and Execution Flow specifications
 - ✅ **[IP-004](./improvement-proposals/IP-004.md)**: Standardized Metadata, Flat Variables, Schemas, and Content Types
+- 🚧 **[IP-005](./improvement-proposals/IP-005.md)**: Core JSON standard plus EVM profile split
 
 #### Planned
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The protocol consists of five core components:
 - ✅ **[IP-002](./improvement-proposals/IP-002.md)**: MDAST Content Representation
 - 🚧 **[IP-003](https://github.com/ConsenSysMesh/agreements-protocol/pull/16)**: Proofs and Execution Flow specifications
 - ✅ **[IP-004](./improvement-proposals/IP-004.md)**: Standardized Metadata, Flat Variables, Schemas, and Content Types
-- 🚧 **[IP-005](./improvement-proposals/IP-005.md)**: Core JSON standard plus EVM profile split
+- 🚧 **[IP-005](./improvement-proposals/IP-005.md)**: Core JSON standard plus composable profiles
 
 #### Planned
 

--- a/improvement-proposals/IP-005.md
+++ b/improvement-proposals/IP-005.md
@@ -1,0 +1,313 @@
+# IP-005 (DRAFT): Split the Standard into a Core JSON Standard and an EVM Profile
+
+## Executive Summary
+
+This proposal splits the current standard into:
+
+1. A chain-neutral, JSON-based core standard
+2. A JSON-based EVM profile that composes with the core
+
+The goal is to keep EVM-specific implementation details out of the base standard while still making the EVM profile exact enough to match the EVM implementation 1:1 at the wire format level.
+
+A valid EVM agreement remains a single JSON document. It is not a different encoding. It is:
+
+- valid against the core schema, and
+- valid against the EVM profile schema
+
+## Problem Statement
+
+The current repository mixes chain-neutral concepts and EVM-specific concepts in the same base layer:
+
+- Core variables currently include `address` as a base type
+- Core execution currently enumerates `verified-credential-eip712.schema.json`
+- The EIP-712 VC wrapper is documented as part of the base standard
+- Examples use an `address` content node even though the checked-in MDAST schema does not define it
+
+This creates three problems:
+
+1. The base standard is not actually chain-neutral
+2. The schema surface is already drifting from the examples
+3. The boundary between standard and implementation is implicit instead of explicit
+
+## Goals
+
+- Keep the standard JSON-based
+- Make the core standard chain-neutral
+- Preserve a strict EVM profile, not a loose extension bag
+- Ensure the EVM profile matches the EVM implementation 1:1 at the serialized JSON layer
+- Allow future profiles without changing the core document model each time
+
+## Non-Goals
+
+- Replacing JSON with another representation
+- Standardizing non-EVM profiles in this proposal
+- Redesigning the DFSM/ASM roadmap
+- Finalizing every future proof format in advance
+
+## Proposal
+
+### 1. Introduce an Explicit Core/Profile Declaration
+
+Each agreement document SHOULD declare the core version it targets and the profiles it conforms to.
+
+Draft shape:
+
+```json
+{
+  "standard": {
+    "id": "agreements",
+    "coreVersion": "1.1.0-draft",
+    "profiles": [
+      {
+        "id": "evm",
+        "version": "1.0.0-draft"
+      }
+    ]
+  },
+  "metadata": {},
+  "variables": [],
+  "content": {},
+  "execution": {}
+}
+```
+
+Notes:
+
+- A core-only agreement uses an empty `profiles` array
+- An EVM agreement includes the `evm` profile entry
+- The agreement remains one JSON document
+
+### 2. Make the Core Variable Model Primitive and Semantic
+
+The core schema MUST not treat `address` as a built-in base type.
+
+Instead, the core variable model SHOULD use:
+
+- a primitive data type
+- an optional semantic type
+
+Draft shape:
+
+```json
+{
+  "id": "grantRecipientAddress",
+  "type": "string",
+  "semanticType": "evm/address",
+  "name": "Grant Recipient Address",
+  "description": "Address of the grant recipient",
+  "validation": {
+    "required": true
+  }
+}
+```
+
+Implications:
+
+- Core owns primitive types such as `string`, `number`, `boolean`, `integer`, `dateTime`, `uri`, `object`, and `array`
+- Profiles own domain semantics such as `evm/address`
+- The EVM profile adds the `0x...` address pattern and any checksum or normalization rules
+
+This keeps core neutral while preserving strict EVM validation.
+
+### 3. Keep the Core Content Model Generic
+
+The core content model SHOULD remain JSON-based and support the existing `md` and `mdast` formats.
+
+The core MDAST surface SHOULD define only generic custom nodes needed by the standard itself. In practice, that means:
+
+- keep `variable`
+- do not define `address` as a core node
+
+Core example:
+
+```json
+{
+  "type": "variable",
+  "id": "grantRecipientAddress"
+}
+```
+
+Consequences:
+
+- Literal EVM addresses in agreement prose should be represented as variable values or plain text
+- Address-specific display behavior is an EVM rendering concern, not a core AST concern
+- If deterministic display hints are needed later, they should be introduced as generic variable rendering hints, not as an `address` node
+
+### 4. Make Core Execution Format-Agnostic
+
+The execution model itself remains part of core. The proof format does not.
+
+Core SHOULD define DFSM structure such as:
+
+- `states`
+- `inputs`
+- `transitions`
+- `conditions`
+
+But core MUST not enumerate a single EVM proof schema.
+
+Draft core input shape:
+
+```json
+{
+  "id": "grantRecipientAcceptance",
+  "format": "evm/eip712-attestation",
+  "schemaRef": "schemas/profiles/evm/execution/input-eip712-attestation.schema.json",
+  "displayName": "Grant Recipient Signature",
+  "description": "Grant recipient acceptance attestation",
+  "constraints": {
+    "signer": "${grantRecipientAddress}",
+    "payload": {
+      "hasAcceptedTerms": true
+    }
+  }
+}
+```
+
+Notes:
+
+- Core knows that an input has a format, a schema reference, and constraints
+- Core does not know what `evm/eip712-attestation` means
+- The profile schema validates the `constraints` object for that format
+
+This keeps the state machine standard neutral while letting the EVM profile be exact.
+
+### 5. Define the EVM Profile as a Strict Schema Composition
+
+The EVM profile SHOULD be expressed as an additional JSON Schema layer over the core schema, not as a sidecar spec that tools interpret informally.
+
+Draft composition pattern:
+
+```json
+{
+  "$id": "https://example.com/schemas/profiles/evm/agreement.schema.json",
+  "allOf": [
+    {
+      "$ref": "../../core/agreement.schema.json"
+    },
+    {
+      "properties": {
+        "standard": {
+          "properties": {
+            "profiles": {
+              "contains": {
+                "type": "object",
+                "required": ["id", "version"],
+                "properties": {
+                  "id": {
+                    "const": "evm"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+The EVM profile then adds strict rules for:
+
+- `semanticType: "evm/address"`
+- `format: "evm/eip712-attestation"`
+- `format: "evm/transaction-receipt"`
+- EVM envelope schemas such as an EIP-712 VC wrapper
+- any profile-specific canonicalization and hashing rules
+
+### 6. Treat the VC Wrapper as an EVM Envelope, Not Core
+
+The current EIP-712 VC wrapper should move out of the core standard.
+
+It SHOULD become an EVM profile envelope schema, for example:
+
+- `schemas/profiles/evm/envelopes/agreement-vc-eip712.schema.json`
+
+The wrapped agreement inside the envelope remains the same core-plus-profile JSON agreement.
+
+### 7. Define 1:1 with the EVM Implementation at the Wire Format Layer
+
+This proposal defines "1:1" as follows:
+
+- The EVM implementation MUST accept the exact JSON document defined by the EVM profile
+- The EVM implementation MUST emit the exact JSON document defined by the EVM profile
+- No required EVM semantics may exist only in implementation code and not in the profile schema
+- No profile fields may exist only in schema prose and not in implementation behavior
+
+Internal runtime objects may differ. The serialized agreement, inputs, envelopes, and validation behavior may not.
+
+## Proposed File Layout
+
+```text
+schemas/
+  core/
+    agreement.schema.json
+    metadata.schema.json
+    variables.schema.json
+    content.schema.json
+    mdast.schema.json
+    execution/
+      dfsm.schema.json
+      input.schema.json
+  profiles/
+    evm/
+      agreement.schema.json
+      variables/
+        evm-address.semantic.schema.json
+      execution/
+        input-eip712-attestation.schema.json
+        input-transaction-receipt.schema.json
+      envelopes/
+        agreement-vc-eip712.schema.json
+
+templates/
+  core/
+    consulting-agreement.core.json
+  profiles/
+    evm/
+      grant-agreement.evm.json
+```
+
+## Migration Plan
+
+### Phase 1: Add the New Boundary Without Breaking Existing Consumers
+
+- Add the new core and EVM profile schemas alongside the current top-level schemas
+- Mark the current root schemas as legacy once the replacements exist
+- Port the current grant example into an EVM profile example
+
+### Phase 2: Move EVM-Specific Rules Out of Core
+
+- Replace base `address` with primitive `type` plus `semanticType`
+- Remove EIP-712 schema enumeration from the core execution schema
+- Move the VC wrapper into the EVM profile envelope layer
+- Remove `address` from core MDAST examples
+
+### Phase 3: Lock the EVM Profile to the Implementation
+
+- Create golden JSON fixtures for EVM agreements, EIP-712 inputs, and envelopes
+- Validate those fixtures against the EVM profile schema
+- Require the EVM implementation to round-trip those fixtures without shape drift
+
+## Acceptance Criteria
+
+This IP should be considered successful when all of the following are true:
+
+1. A core-only agreement can be authored and validated without any EVM terms in the core schema
+2. An EVM agreement validates as core plus EVM profile, using one JSON document
+3. No EVM-specific enum or proof schema is required by the core schemas
+4. The example EVM agreement and the EVM implementation round-trip the same JSON shape
+5. The base MDAST schema and examples no longer disagree about custom nodes
+
+## Open Questions
+
+1. Should the version declaration live at top-level `standard`, or under `metadata.conformsTo` for backward compatibility?
+2. Should generic rendering hints be added to `variable` nodes now, or deferred until there is a concrete non-EVM need?
+3. Should profile identifiers be short strings such as `evm`, or URIs such as `urn:agreements:profile:evm`?
+
+## Recommendation
+
+Proceed with the split.
+
+The current repo already shows the cost of not having a hard boundary: EVM semantics are in the base layer, and the examples are drifting from the schemas. A core-plus-profile model fixes the layering problem without giving up JSON, and it gives the EVM implementation a strict contract instead of an implied one.

--- a/improvement-proposals/IP-005.md
+++ b/improvement-proposals/IP-005.md
@@ -1,48 +1,54 @@
-# IP-005 (DRAFT): Split the Standard into a Core JSON Standard and an EVM Profile
+# IP-005 (DRAFT): Split the Standard into a Core JSON Standard and Composable Profiles
 
 ## Executive Summary
 
 This proposal splits the current standard into:
 
 1. A chain-neutral, JSON-based core standard
-2. A JSON-based EVM profile that composes with the core
+2. A set of orthogonal, JSON-based profiles that compose with the core
 
-The goal is to keep EVM-specific implementation details out of the base standard while still making the EVM profile exact enough to match the EVM implementation 1:1 at the wire format level.
+The immediate profiles this proposal uses to define the boundary are:
 
-A valid EVM agreement remains a single JSON document. It is not a different encoding. It is:
+- `evm` for EVM runtime and data-model semantics
+- `vc` for Verifiable Credential envelope semantics
+- `eip712` for typed-data proof and signature semantics
 
-- valid against the core schema, and
-- valid against the EVM profile schema
+The goal is to keep platform concerns, envelope concerns, and proof-format concerns out of the base standard and out of each other unless they are explicitly composed.
+
+A valid agreement remains a JSON document. A valid wrapped agreement or proof artifact also remains JSON. Composition changes which schemas apply, not the encoding.
 
 ## Problem Statement
 
-The current repository mixes chain-neutral concepts and EVM-specific concepts in the same base layer:
+The current repository mixes multiple concerns into the same base layer:
 
 - Core variables currently include `address` as a base type
-- Core execution currently enumerates `verified-credential-eip712.schema.json`
-- The EIP-712 VC wrapper is documented as part of the base standard
+- Core execution currently enumerates an EIP-712-specific schema
+- The VC wrapper is documented as if it were part of the base agreement model
+- EVM, VC, and proof-format semantics are effectively bundled together
 - Examples use an `address` content node even though the checked-in MDAST schema does not define it
 
-This creates three problems:
+This creates four problems:
 
 1. The base standard is not actually chain-neutral
-2. The schema surface is already drifting from the examples
-3. The boundary between standard and implementation is implicit instead of explicit
+2. Envelope semantics and runtime semantics are conflated
+3. Proof-format semantics are bundled into platform semantics
+4. The schema surface is already drifting from the examples
 
 ## Goals
 
 - Keep the standard JSON-based
 - Make the core standard chain-neutral
-- Preserve a strict EVM profile, not a loose extension bag
-- Ensure the EVM profile matches the EVM implementation 1:1 at the serialized JSON layer
-- Allow future profiles without changing the core document model each time
+- Treat platform, envelope, and proof concerns as separate profile dimensions
+- Preserve strict schemas, not a loose extension bag
+- Allow a document to compose multiple profiles explicitly
+- Ensure each implemented profile matches its implementation 1:1 at the serialized JSON layer
 
 ## Non-Goals
 
 - Replacing JSON with another representation
-- Standardizing non-EVM profiles in this proposal
+- Standardizing every future profile in this proposal
 - Redesigning the DFSM/ASM roadmap
-- Finalizing every future proof format in advance
+- Finalizing every future proof system in advance
 
 ## Proposal
 
@@ -61,6 +67,10 @@ Draft shape:
       {
         "id": "evm",
         "version": "1.0.0-draft"
+      },
+      {
+        "id": "eip712",
+        "version": "1.0.0-draft"
       }
     ]
   },
@@ -74,8 +84,10 @@ Draft shape:
 Notes:
 
 - A core-only agreement uses an empty `profiles` array
-- An EVM agreement includes the `evm` profile entry
-- The agreement remains one JSON document
+- A chain-bound execution flow may declare `evm`
+- A typed-data proof flow may declare `eip712`
+- A credential envelope may declare `vc`
+- Many artifacts will validly declare multiple profiles
 
 ### 2. Make the Core Variable Model Primitive and Semantic
 
@@ -105,9 +117,9 @@ Implications:
 
 - Core owns primitive types such as `string`, `number`, `boolean`, `integer`, `dateTime`, `uri`, `object`, and `array`
 - Profiles own domain semantics such as `evm/address`
-- The EVM profile adds the `0x...` address pattern and any checksum or normalization rules
+- The `evm` profile adds `0x...` address rules and any normalization rules
 
-This keeps core neutral while preserving strict EVM validation.
+This keeps core neutral while preserving strict profile validation.
 
 ### 3. Keep the Core Content Model Generic
 
@@ -130,12 +142,12 @@ Core example:
 Consequences:
 
 - Literal EVM addresses in agreement prose should be represented as variable values or plain text
-- Address-specific display behavior is an EVM rendering concern, not a core AST concern
-- If deterministic display hints are needed later, they should be introduced as generic variable rendering hints, not as an `address` node
+- Address-specific display behavior is not a core AST concern
+- If display hints are needed later, they should be introduced as generic rendering hints, not as an `address` node
 
 ### 4. Make Core Execution Format-Agnostic
 
-The execution model itself remains part of core. The proof format does not.
+The execution model itself remains part of core. Platform-specific proof formats do not.
 
 Core SHOULD define DFSM structure such as:
 
@@ -144,15 +156,15 @@ Core SHOULD define DFSM structure such as:
 - `transitions`
 - `conditions`
 
-But core MUST not enumerate a single EVM proof schema.
+But core MUST not enumerate a single proof system or platform-specific input schema.
 
 Draft core input shape:
 
 ```json
 {
   "id": "grantRecipientAcceptance",
-  "format": "evm/eip712-attestation",
-  "schemaRef": "schemas/profiles/evm/execution/input-eip712-attestation.schema.json",
+  "format": "eip712/typed-data-signature",
+  "schemaRef": "schemas/profiles/eip712/execution/input-typed-data-signature.schema.json",
   "displayName": "Grant Recipient Signature",
   "description": "Grant recipient acceptance attestation",
   "constraints": {
@@ -167,75 +179,101 @@ Draft core input shape:
 Notes:
 
 - Core knows that an input has a format, a schema reference, and constraints
-- Core does not know what `evm/eip712-attestation` means
-- The profile schema validates the `constraints` object for that format
+- Core does not know what `eip712/typed-data-signature` means
+- The `eip712` profile validates the typed-data signature structure
+- If `signer` resolves to an `evm/address`, that comes from the `evm` profile, not from the `eip712` profile
 
-This keeps the state machine standard neutral while letting the EVM profile be exact.
+This keeps the state machine standard neutral while letting profiles be exact.
 
-### 5. Define the EVM Profile as a Strict Schema Composition
+### 5. Separate Orthogonal Profile Boundaries
 
-The EVM profile SHOULD be expressed as an additional JSON Schema layer over the core schema, not as a sidecar spec that tools interpret informally.
+Profiles SHOULD be defined around one concern each.
 
-Draft composition pattern:
+#### `evm` Profile
+
+The `evm` profile owns EVM-specific runtime and value semantics such as:
+
+- `semanticType: "evm/address"`
+- chain identifiers and chain-bound references
+- EVM transaction receipts
+- contract, event-log, and state verification constraints
+
+The `evm` profile MUST NOT own VC envelope semantics.
+
+#### `vc` Profile
+
+The `vc` profile owns Verifiable Credential semantics such as:
+
+- VC envelope structure
+- issuer, subject, and context fields
+- credential wrapping rules
+- VC-oriented proof purpose semantics
+
+The `vc` profile MUST NOT imply a specific chain or proof format.
+
+#### `eip712` Profile
+
+The `eip712` profile owns typed-data proof semantics such as:
+
+- typed-data domain structure
+- types and primary type declarations
+- signature encoding and verification rules
+- typed-data payload constraints
+
+The `eip712` profile MUST NOT own VC envelope semantics.
+
+The `eip712` profile SHOULD remain separate from `evm` even when many practical uses compose them together.
+
+### 6. Model Composition Explicitly
+
+Profile composition SHOULD be explicit, both in document declarations and in schema layout.
+
+Examples:
+
+- `core`
+- `core + evm`
+- `core + vc`
+- `core + eip712`
+- `core + evm + eip712`
+- `core + vc + eip712`
+- `core + evm + vc + eip712`
+
+Important consequence:
+
+- A VC envelope signed using EIP-712 is not an `evm` profile artifact
+- It is a composition of `vc` and `eip712`
+- If its proof or signer semantics depend on EVM-specific values, then `evm` is composed explicitly as well
+
+Schema composition pattern:
 
 ```json
 {
-  "$id": "https://example.com/schemas/profiles/evm/agreement.schema.json",
+  "$id": "https://example.com/schemas/compositions/vc-eip712/agreement-envelope.schema.json",
   "allOf": [
     {
-      "$ref": "../../core/agreement.schema.json"
+      "$ref": "../../profiles/vc/agreement-envelope.schema.json"
     },
     {
-      "properties": {
-        "standard": {
-          "properties": {
-            "profiles": {
-              "contains": {
-                "type": "object",
-                "required": ["id", "version"],
-                "properties": {
-                  "id": {
-                    "const": "evm"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+      "$ref": "../../profiles/eip712/agreement-envelope.schema.json"
     }
   ]
 }
 ```
 
-The EVM profile then adds strict rules for:
+The same approach applies to other combined artifacts.
 
-- `semanticType: "evm/address"`
-- `format: "evm/eip712-attestation"`
-- `format: "evm/transaction-receipt"`
-- EVM envelope schemas such as an EIP-712 VC wrapper
-- any profile-specific canonicalization and hashing rules
-
-### 6. Treat the VC Wrapper as an EVM Envelope, Not Core
-
-The current EIP-712 VC wrapper should move out of the core standard.
-
-It SHOULD become an EVM profile envelope schema, for example:
-
-- `schemas/profiles/evm/envelopes/agreement-vc-eip712.schema.json`
-
-The wrapped agreement inside the envelope remains the same core-plus-profile JSON agreement.
-
-### 7. Define 1:1 with the EVM Implementation at the Wire Format Layer
+### 7. Define 1:1 with Implementations at the Wire Format Layer
 
 This proposal defines "1:1" as follows:
 
-- The EVM implementation MUST accept the exact JSON document defined by the EVM profile
-- The EVM implementation MUST emit the exact JSON document defined by the EVM profile
-- No required EVM semantics may exist only in implementation code and not in the profile schema
+- An implementation claiming support for a profile MUST accept the exact JSON shape defined by that profile
+- An implementation claiming support for a profile MUST emit the exact JSON shape defined by that profile
+- No required profile semantics may exist only in implementation code and not in the corresponding profile schema
 - No profile fields may exist only in schema prose and not in implementation behavior
 
-Internal runtime objects may differ. The serialized agreement, inputs, envelopes, and validation behavior may not.
+This applies independently to `evm`, `vc`, and `eip712`, and to any explicit composition schema built from them.
+
+Internal runtime objects may differ. The serialized agreement, envelopes, proofs, and validation behavior may not.
 
 ## Proposed File Layout
 
@@ -256,10 +294,24 @@ schemas/
       variables/
         evm-address.semantic.schema.json
       execution/
-        input-eip712-attestation.schema.json
         input-transaction-receipt.schema.json
-      envelopes/
-        agreement-vc-eip712.schema.json
+    vc/
+      agreement-envelope.schema.json
+      execution/
+        input-verifiable-credential.schema.json
+    eip712/
+      execution/
+        input-typed-data-signature.schema.json
+      proofs/
+        typed-data-proof.schema.json
+  compositions/
+    evm-eip712/
+      execution/
+        input-eip712-attestation.schema.json
+    vc-eip712/
+      agreement-envelope.schema.json
+    evm-vc-eip712/
+      agreement-envelope.schema.json
 
 templates/
   core/
@@ -267,47 +319,64 @@ templates/
   profiles/
     evm/
       grant-agreement.evm.json
+    vc/
+      consulting-agreement.vc.json
+  compositions/
+    evm-eip712/
+      grant-agreement.eip712.json
+    vc-eip712/
+      grant-agreement.vc-eip712.json
 ```
 
 ## Migration Plan
 
 ### Phase 1: Add the New Boundary Without Breaking Existing Consumers
 
-- Add the new core and EVM profile schemas alongside the current top-level schemas
-- Mark the current root schemas as legacy once the replacements exist
-- Port the current grant example into an EVM profile example
+- Add the new core, `evm`, `vc`, and `eip712` schema trees alongside the current top-level schemas
+- Mark the current root schemas as legacy once replacements exist
+- Move the current examples into the appropriate profile or composition buckets
 
-### Phase 2: Move EVM-Specific Rules Out of Core
+### Phase 2: Remove Mixed Concerns from Core
 
 - Replace base `address` with primitive `type` plus `semanticType`
 - Remove EIP-712 schema enumeration from the core execution schema
-- Move the VC wrapper into the EVM profile envelope layer
+- Remove VC wrapper semantics from the base agreement model
 - Remove `address` from core MDAST examples
 
-### Phase 3: Lock the EVM Profile to the Implementation
+### Phase 3: Split Existing Bundles into Explicit Composition Schemas
 
-- Create golden JSON fixtures for EVM agreements, EIP-712 inputs, and envelopes
-- Validate those fixtures against the EVM profile schema
-- Require the EVM implementation to round-trip those fixtures without shape drift
+- Move EVM transaction and address rules into `profiles/evm`
+- Move VC wrapper rules into `profiles/vc`
+- Move typed-data signature rules into `profiles/eip712`
+- Rebuild any combined artifacts as explicit composition schemas rather than burying them under one profile
+
+### Phase 4: Lock Profile Schemas to Implementations
+
+- Create golden JSON fixtures for each standalone profile
+- Create golden JSON fixtures for each supported composition
+- Validate fixtures against the appropriate standalone and composition schemas
+- Require implementations to round-trip those fixtures without shape drift
 
 ## Acceptance Criteria
 
 This IP should be considered successful when all of the following are true:
 
-1. A core-only agreement can be authored and validated without any EVM terms in the core schema
-2. An EVM agreement validates as core plus EVM profile, using one JSON document
-3. No EVM-specific enum or proof schema is required by the core schemas
-4. The example EVM agreement and the EVM implementation round-trip the same JSON shape
-5. The base MDAST schema and examples no longer disagree about custom nodes
+1. A core-only agreement can be authored and validated without any `evm`, `vc`, or `eip712` terms in the core schema
+2. An `evm` agreement validates without requiring VC semantics
+3. A `vc` artifact validates without requiring EVM semantics
+4. An `eip712` proof artifact validates without being treated as a VC artifact by default
+5. Combined artifacts such as VC-with-EIP712 are represented as explicit compositions, not hidden inside one profile
+6. The base MDAST schema and examples no longer disagree about custom nodes
+7. Each implemented profile and composition round-trips the same JSON shape it claims to support
 
 ## Open Questions
 
 1. Should the version declaration live at top-level `standard`, or under `metadata.conformsTo` for backward compatibility?
-2. Should generic rendering hints be added to `variable` nodes now, or deferred until there is a concrete non-EVM need?
-3. Should profile identifiers be short strings such as `evm`, or URIs such as `urn:agreements:profile:evm`?
+2. Should profile identifiers be short strings such as `evm`, `vc`, and `eip712`, or URIs such as `urn:agreements:profile:evm`?
+3. Should `eip712` formally require `evm`, or only when the chosen typed-data domain uses EVM-specific fields such as `chainId` or `verifyingContract`?
 
 ## Recommendation
 
-Proceed with the split.
+Proceed with the split, but make it a split into composable profiles rather than a single `core + evm` layering.
 
-The current repo already shows the cost of not having a hard boundary: EVM semantics are in the base layer, and the examples are drifting from the schemas. A core-plus-profile model fixes the layering problem without giving up JSON, and it gives the EVM implementation a strict contract instead of an implied one.
+The current repo already shows the cost of not having a hard boundary: base schemas include EVM assumptions, VC wrapping is treated like base structure, and proof semantics are bundled into runtime semantics. A core-plus-composable-profiles model fixes the layering problem without giving up JSON, and it gives each implementation a strict contract instead of an implied one.


### PR DESCRIPTION
## Summary
- add draft IP-005 for splitting the standard into a chain-neutral core and a strict EVM profile
- define the proposed schema boundary, migration plan, and conformance criteria
- link the new draft from the README proposal list

## Testing
- not run (docs-only change)