### PR TITLE
(2/3) Add composable profile schemas and examples

### DIFF
--- a/schemas/compositions/evm-eip712/agreement.schema.json
+++ b/schemas/compositions/evm-eip712/agreement.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/compositions/evm-eip712/agreement.schema.json",
+  "title": "Agreement Document (EVM + EIP-712 Composition)",
+  "description": "Agreement document that composes the EVM and EIP-712 profiles.",
+  "allOf": [
+    {
+      "$ref": "../../profiles/evm/agreement.schema.json"
+    },
+    {
+      "$ref": "../../profiles/eip712/agreement.schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "standard": {
+          "type": "object",
+          "properties": {
+            "profiles": {
+              "type": "array",
+              "allOf": [
+                {
+                  "contains": {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": {
+                      "id": {
+                        "const": "evm"
+                      }
+                    }
+                  }
+                },
+                {
+                  "contains": {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": {
+                      "id": {
+                        "const": "eip712"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "execution": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "dfsm"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "inputs": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "allOf": [
+                      {
+                        "$ref": "../../core/execution/input.schema.json"
+                      },
+                      {
+                        "if": {
+                          "properties": {
+                            "format": {
+                              "const": "eip712/typed-data-signature"
+                            }
+                          },
+                          "required": ["format"]
+                        },
+                        "then": {
+                          "$ref": "./execution/input-eip712-attestation.schema.json"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/compositions/evm-eip712/execution/input-eip712-attestation.schema.json
+++ b/schemas/compositions/evm-eip712/execution/input-eip712-attestation.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/compositions/evm-eip712/execution/input-eip712-attestation.schema.json",
+  "title": "EVM + EIP-712 Attestation Input",
+  "description": "Execution input describing an EIP-712 typed-data signature whose signer is expected to resolve to an EVM address.",
+  "$defs": {
+    "typeField": {
+      "type": "object",
+      "required": ["name", "type"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "../../../core/execution/input.schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "format": {
+          "const": "eip712/typed-data-signature"
+        },
+        "schemaRef": {
+          "const": "schemas/compositions/evm-eip712/execution/input-eip712-attestation.schema.json"
+        },
+        "constraints": {
+          "type": "object",
+          "required": ["signer", "signerSemanticType", "payload"],
+          "properties": {
+            "signer": {
+              "type": "string"
+            },
+            "signerSemanticType": {
+              "const": "evm/address"
+            },
+            "payload": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "proofPurpose": {
+              "type": "string",
+              "enum": [
+                "assertionMethod",
+                "authentication",
+                "keyAgreement",
+                "contractAgreement",
+                "capabilityInvocation",
+                "capabilityDelegation"
+              ]
+            },
+            "primaryType": {
+              "type": "string"
+            },
+            "domain": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                },
+                "chainId": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "verifyingContract": {
+                  "type": "string",
+                  "pattern": "^0x[a-fA-F0-9]{40}$"
+                },
+                "salt": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "types": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/$defs/typeField"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  ]
+}

--- a/schemas/compositions/evm-vc-eip712/agreement-envelope.schema.json
+++ b/schemas/compositions/evm-vc-eip712/agreement-envelope.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/compositions/evm-vc-eip712/agreement-envelope.schema.json",
+  "title": "Agreement VC Envelope (EVM + VC + EIP-712 Composition)",
+  "description": "VC envelope with an EIP-712 proof that wraps an agreement composing the EVM and EIP-712 profiles.",
+  "allOf": [
+    {
+      "$ref": "../vc-eip712/agreement-envelope.schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "credentialSubject": {
+          "type": "object",
+          "properties": {
+            "agreement": {
+              "$ref": "../evm-eip712/agreement.schema.json"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/compositions/vc-eip712/agreement-envelope.schema.json
+++ b/schemas/compositions/vc-eip712/agreement-envelope.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/compositions/vc-eip712/agreement-envelope.schema.json",
+  "title": "Agreement VC Envelope (VC + EIP-712 Composition)",
+  "description": "Verifiable Credential envelope whose proof is an EIP-712 typed-data proof.",
+  "allOf": [
+    {
+      "$ref": "../../profiles/vc/agreement-envelope.schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "proof": {
+          "$ref": "../../profiles/eip712/proofs/typed-data-proof.schema.json"
+        }
+      }
+    }
+  ]
+}

--- a/schemas/core/agreement.schema.json
+++ b/schemas/core/agreement.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/core/agreement.schema.json",
+  "title": "Agreement Document (Core)",
+  "description": "Chain-neutral JSON agreement document.",
+  "$defs": {
+    "profile": {
+      "type": "object",
+      "required": ["id", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[A-Za-z0-9.-]+)?$"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "required": ["standard", "metadata", "variables", "content"],
+  "properties": {
+    "standard": {
+      "type": "object",
+      "required": ["id", "coreVersion", "profiles"],
+      "properties": {
+        "id": {
+          "const": "agreements"
+        },
+        "coreVersion": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[A-Za-z0-9.-]+)?$"
+        },
+        "profiles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/profile"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "metadata": {
+      "$ref": "./metadata.schema.json"
+    },
+    "variables": {
+      "$ref": "./variables.schema.json"
+    },
+    "content": {
+      "$ref": "./content.schema.json"
+    },
+    "execution": {
+      "type": "object",
+      "required": ["type", "data"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["dfsm"],
+          "description": "Execution model type"
+        },
+        "data": {}
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "dfsm"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": {
+              "data": {
+                "$ref": "./execution/dfsm.schema.json"
+              }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/core/content.schema.json
+++ b/schemas/core/content.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/core/content.schema.json",
+  "title": "Agreement Content",
+  "description": "Chain-neutral agreement content encoded as Markdown or MDAST.",
+  "type": "object",
+  "required": ["type", "data"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["md", "mdast"],
+      "description": "Content representation format"
+    },
+    "data": {}
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "md"
+          }
+        },
+        "required": ["type"]
+      },
+      "then": {
+        "properties": {
+          "data": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "mdast"
+          }
+        },
+        "required": ["type"]
+      },
+      "then": {
+        "properties": {
+          "data": {
+            "$ref": "./mdast.schema.json"
+          }
+        }
+      }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/schemas/core/execution/dfsm.schema.json
+++ b/schemas/core/execution/dfsm.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/core/execution/dfsm.schema.json",
+  "title": "Deterministic Finite State Machine Execution Model",
+  "description": "Chain-neutral DFSM execution model driven by verifiable inputs.",
+  "$defs": {
+    "condition": {
+      "type": "object",
+      "required": ["type", "inputs"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["isValid"],
+          "description": "Type of transition condition"
+        },
+        "inputs": {
+          "type": "array",
+          "description": "Input identifiers to evaluate for this condition",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z][A-Za-z0-9_-]*$"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "transition": {
+      "type": "object",
+      "required": ["from", "to", "conditions"],
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "Starting state of the transition"
+        },
+        "to": {
+          "type": "string",
+          "description": "Ending state of the transition"
+        },
+        "conditions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/condition"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "required": ["states", "transitions"],
+  "properties": {
+    "states": {
+      "type": "array",
+      "description": "List of possible states for the agreement",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "inputs": {
+      "type": "object",
+      "description": "Input definitions that can be used in transitions",
+      "propertyNames": {
+        "pattern": "^[A-Za-z][A-Za-z0-9_-]*$"
+      },
+      "additionalProperties": {
+        "$ref": "./input.schema.json"
+      }
+    },
+    "transitions": {
+      "type": "array",
+      "description": "State transitions with conditions",
+      "items": {
+        "$ref": "#/$defs/transition"
+      },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/core/execution/input.schema.json
+++ b/schemas/core/execution/input.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/core/execution/input.schema.json",
+  "title": "Execution Input Definition",
+  "description": "Chain-neutral definition of a verifiable execution input.",
+  "type": "object",
+  "required": ["id", "format", "schemaRef", "displayName", "description"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9_-]*$",
+      "description": "Unique identifier for the input"
+    },
+    "format": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:/[a-z0-9][a-z0-9-]*)+$",
+      "description": "Profile-defined input format identifier"
+    },
+    "schemaRef": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Schema path that defines the input format"
+    },
+    "displayName": {
+      "type": "string",
+      "description": "Human-readable name for the input"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of the input's purpose"
+    },
+    "constraints": {
+      "type": "object",
+      "description": "Format-specific constraints that a profile schema can interpret",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/core/mdast.schema.json
+++ b/schemas/core/mdast.schema.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/core/mdast.schema.json",
+  "title": "Agreement Markdown AST",
+  "description": "MDAST-compatible content tree for agreement documents. The core schema only standardizes generic Markdown nodes plus the variable node.",
+  "$ref": "#/$defs/node",
+  "$defs": {
+    "node": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "blockquote",
+            "break",
+            "code",
+            "definition",
+            "emphasis",
+            "heading",
+            "html",
+            "image",
+            "imageReference",
+            "inlineCode",
+            "link",
+            "linkReference",
+            "list",
+            "listItem",
+            "paragraph",
+            "root",
+            "strong",
+            "text",
+            "thematicBreak",
+            "variable"
+          ]
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/node"
+          }
+        },
+        "value": {
+          "type": "string"
+        },
+        "depth": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 6
+        },
+        "lang": {
+          "type": "string"
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
+        },
+        "alt": {
+          "type": "string"
+        },
+        "checked": {
+          "type": ["boolean", "null"]
+        },
+        "spread": {
+          "type": "boolean"
+        },
+        "ordered": {
+          "type": "boolean"
+        },
+        "start": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "id": {
+          "type": "string"
+        },
+        "property": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "heading"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["depth", "children"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "code"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["value"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "html"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["value"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "image"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["url"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "link"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["url", "children"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "list"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["children"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "listItem"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["children"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "paragraph"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["children"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "root"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["children"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "text"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["value"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "variable"
+              }
+            },
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["id"]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/core/metadata.schema.json
+++ b/schemas/core/metadata.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/core/metadata.schema.json",
+  "title": "Agreement Metadata",
+  "description": "Chain-neutral metadata for an agreement document.",
+  "type": "object",
+  "required": ["id", "templateId", "version", "createdAt", "name", "author", "description"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^did:.*$",
+      "description": "Unique identifier for the agreement instance"
+    },
+    "templateId": {
+      "type": "string",
+      "pattern": "^did:template:.*$",
+      "description": "Identifier for the template type"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Semantic version of the template payload"
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Creation timestamp"
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable name of the template"
+    },
+    "author": {
+      "type": "string",
+      "description": "Author or organization that created the template"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of the template's purpose"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/core/variables.schema.json
+++ b/schemas/core/variables.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/core/variables.schema.json",
+  "title": "Agreement Variables",
+  "description": "Chain-neutral variable definitions for agreement documents.",
+  "$defs": {
+    "jsonValue": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "additionalProperties": true
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/jsonValue"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "validation": {
+      "type": "object",
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pattern": {
+          "type": "string",
+          "format": "regex"
+        },
+        "min": {
+          "type": "number"
+        },
+        "max": {
+          "type": "number"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "variable": {
+      "type": "object",
+      "required": ["id", "type", "name", "description"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[A-Za-z][A-Za-z0-9_-]*$",
+          "description": "Unique identifier for the variable"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["string", "number", "integer", "boolean", "dateTime", "uri", "object", "array"],
+          "description": "Primitive data type of the variable"
+        },
+        "semanticType": {
+          "type": "string",
+          "description": "Optional profile-defined semantic meaning for the primitive value"
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the variable's purpose"
+        },
+        "value": {
+          "$ref": "#/$defs/jsonValue",
+          "description": "Current value of the variable"
+        },
+        "defaultValue": {
+          "$ref": "#/$defs/jsonValue",
+          "description": "Default value if none is provided"
+        },
+        "validation": {
+          "$ref": "#/$defs/validation"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "type": "array",
+  "items": {
+    "$ref": "#/$defs/variable"
+  }
+}

--- a/schemas/profiles/eip712/agreement.schema.json
+++ b/schemas/profiles/eip712/agreement.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/profiles/eip712/agreement.schema.json",
+  "title": "Agreement Document (EIP-712 Profile)",
+  "description": "JSON agreement document that conforms to the core schema and the EIP-712 profile. The EIP-712 profile owns typed-data signature semantics only.",
+  "allOf": [
+    {
+      "$ref": "../../core/agreement.schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "standard": {
+          "type": "object",
+          "properties": {
+            "profiles": {
+              "type": "array",
+              "contains": {
+                "type": "object",
+                "required": ["id", "version"],
+                "properties": {
+                  "id": {
+                    "const": "eip712"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minContains": 1
+            }
+          }
+        },
+        "execution": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "dfsm"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "inputs": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "allOf": [
+                      {
+                        "$ref": "../../core/execution/input.schema.json"
+                      },
+                      {
+                        "if": {
+                          "properties": {
+                            "format": {
+                              "const": "eip712/typed-data-signature"
+                            }
+                          },
+                          "required": ["format"]
+                        },
+                        "then": {
+                          "$ref": "./execution/input-typed-data-signature.schema.json"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/profiles/eip712/execution/input-typed-data-signature.schema.json
+++ b/schemas/profiles/eip712/execution/input-typed-data-signature.schema.json
@@ -91,7 +91,7 @@
               }
             }
           },
-          "additionalProperties": false
+          "additionalProperties": true
         }
       }
     }

--- a/schemas/profiles/eip712/execution/input-typed-data-signature.schema.json
+++ b/schemas/profiles/eip712/execution/input-typed-data-signature.schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/profiles/eip712/execution/input-typed-data-signature.schema.json",
+  "title": "EIP-712 Typed Data Signature Input",
+  "description": "Execution input describing an expected EIP-712 typed-data signature.",
+  "$defs": {
+    "typeField": {
+      "type": "object",
+      "required": ["name", "type"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "../../../core/execution/input.schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "format": {
+          "const": "eip712/typed-data-signature"
+        },
+        "schemaRef": {
+          "type": "string"
+        },
+        "constraints": {
+          "type": "object",
+          "required": ["signer", "payload"],
+          "properties": {
+            "signer": {
+              "type": "string",
+              "description": "Expression or literal that resolves to the expected signer"
+            },
+            "payload": {
+              "type": "object",
+              "description": "Expected claims contained in the signed typed data",
+              "additionalProperties": true
+            },
+            "proofPurpose": {
+              "type": "string",
+              "enum": [
+                "assertionMethod",
+                "authentication",
+                "keyAgreement",
+                "contractAgreement",
+                "capabilityInvocation",
+                "capabilityDelegation"
+              ]
+            },
+            "primaryType": {
+              "type": "string"
+            },
+            "domain": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                },
+                "chainId": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "verifyingContract": {
+                  "type": "string",
+                  "pattern": "^0x[a-fA-F0-9]{40}$"
+                },
+                "salt": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            "types": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/$defs/typeField"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  ]
+}

--- a/schemas/profiles/eip712/proofs/typed-data-proof.schema.json
+++ b/schemas/profiles/eip712/proofs/typed-data-proof.schema.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/profiles/eip712/proofs/typed-data-proof.schema.json",
+  "title": "EIP-712 Typed Data Proof",
+  "description": "Proof object representing an EIP-712 typed-data signature.",
+  "$defs": {
+    "typeField": {
+      "type": "object",
+      "required": ["name", "type"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "required": ["type", "created", "proofPurpose", "verificationMethod", "eip712", "proofValue"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["EthereumEip712Signature2021"]
+    },
+    "created": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "proofPurpose": {
+      "type": "string",
+      "enum": [
+        "assertionMethod",
+        "authentication",
+        "keyAgreement",
+        "contractAgreement",
+        "capabilityInvocation",
+        "capabilityDelegation"
+      ]
+    },
+    "verificationMethod": {
+      "type": "string",
+      "format": "uri"
+    },
+    "eip712": {
+      "type": "object",
+      "required": ["domain", "types", "primaryType"],
+      "properties": {
+        "domain": {
+          "type": "object",
+          "required": ["name", "version"],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "chainId": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "verifyingContract": {
+              "type": "string",
+              "pattern": "^0x[a-fA-F0-9]{40}$"
+            },
+            "salt": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "types": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/typeField"
+            }
+          }
+        },
+        "primaryType": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "proofValue": {
+      "type": "string",
+      "pattern": "^0x[a-fA-F0-9]+$"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/profiles/evm/agreement.schema.json
+++ b/schemas/profiles/evm/agreement.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/profiles/evm/agreement.schema.json",
+  "title": "Agreement Document (EVM Profile)",
+  "description": "JSON agreement document that conforms to the core schema and the EVM profile. The EVM profile owns runtime and value semantics only; it does not own VC or EIP-712 envelope semantics.",
+  "allOf": [
+    {
+      "$ref": "../../core/agreement.schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "standard": {
+          "type": "object",
+          "properties": {
+            "profiles": {
+              "type": "array",
+              "contains": {
+                "type": "object",
+                "required": ["id", "version"],
+                "properties": {
+                  "id": {
+                    "const": "evm"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "minContains": 1
+            }
+          }
+        },
+        "variables": {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {
+                "$ref": "../../core/variables.schema.json#/$defs/variable"
+              },
+              {
+                "if": {
+                  "properties": {
+                    "semanticType": {
+                      "const": "evm/address"
+                    }
+                  },
+                  "required": ["semanticType"]
+                },
+                "then": {
+                  "$ref": "./variables/evm-address.semantic.schema.json"
+                }
+              }
+            ]
+          }
+        },
+        "execution": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "dfsm"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "inputs": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "allOf": [
+                      {
+                        "$ref": "../../core/execution/input.schema.json"
+                      },
+                      {
+                        "if": {
+                          "properties": {
+                            "format": {
+                              "const": "evm/transaction-receipt"
+                            }
+                          },
+                          "required": ["format"]
+                        },
+                        "then": {
+                          "$ref": "./execution/input-transaction-receipt.schema.json"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/profiles/evm/execution/input-transaction-receipt.schema.json
+++ b/schemas/profiles/evm/execution/input-transaction-receipt.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/profiles/evm/execution/input-transaction-receipt.schema.json",
+  "title": "EVM Transaction Receipt Input",
+  "description": "Execution input describing an expected transaction receipt in the EVM profile.",
+  "allOf": [
+    {
+      "$ref": "../../../core/execution/input.schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "format": {
+          "const": "evm/transaction-receipt"
+        },
+        "schemaRef": {
+          "const": "schemas/profiles/evm/execution/input-transaction-receipt.schema.json"
+        },
+        "constraints": {
+          "type": "object",
+          "required": ["chainId"],
+          "properties": {
+            "chainId": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "transactionHash": {
+              "type": "string",
+              "pattern": "^0x[a-fA-F0-9]{64}$"
+            },
+            "contractAddress": {
+              "type": "string",
+              "pattern": "^0x[a-fA-F0-9]{40}$"
+            },
+            "status": {
+              "type": "string",
+              "enum": ["success", "reverted"]
+            },
+            "event": {
+              "type": "object",
+              "required": ["name"],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "args": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  ]
+}

--- a/schemas/profiles/evm/variables/evm-address.semantic.schema.json
+++ b/schemas/profiles/evm/variables/evm-address.semantic.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/profiles/evm/variables/evm-address.semantic.schema.json",
+  "title": "EVM Address Variable Semantic",
+  "description": "Profile rule for variables that carry an EVM address.",
+  "allOf": [
+    {
+      "$ref": "../../../core/variables.schema.json#/$defs/variable"
+    },
+    {
+      "type": "object",
+      "required": ["type", "semanticType", "validation"],
+      "properties": {
+        "type": {
+          "const": "string"
+        },
+        "semanticType": {
+          "const": "evm/address"
+        },
+        "value": {
+          "type": ["string", "null"]
+        },
+        "defaultValue": {
+          "type": ["string", "null"]
+        },
+        "validation": {
+          "type": "object",
+          "required": ["pattern"],
+          "properties": {
+            "required": {
+              "type": "boolean"
+            },
+            "minLength": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "maxLength": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "pattern": {
+              "const": "^0x[a-fA-F0-9]{40}$"
+            },
+            "message": {
+              "type": "string"
+            },
+            "min": {
+              "type": "number"
+            },
+            "max": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": ["value"]
+          },
+          "then": {
+            "properties": {
+              "value": {
+                "pattern": "^0x[a-fA-F0-9]{40}$"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "defaultValue": {
+                "type": "string"
+              }
+            },
+            "required": ["defaultValue"]
+          },
+          "then": {
+            "properties": {
+              "defaultValue": {
+                "pattern": "^0x[a-fA-F0-9]{40}$"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/schemas/profiles/vc/agreement-envelope.schema.json
+++ b/schemas/profiles/vc/agreement-envelope.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/profiles/vc/agreement-envelope.schema.json",
+  "title": "Agreement VC Envelope",
+  "description": "Verifiable Credential envelope for wrapping an agreement document. This profile owns VC structure only and does not imply a specific proof system.",
+  "type": "object",
+  "required": ["@context", "type", "issuer", "issuanceDate", "credentialSubject", "proof"],
+  "properties": {
+    "@context": {
+      "type": ["string", "array"],
+      "description": "JSON-LD context for the credential"
+    },
+    "id": {
+      "type": "string",
+      "format": "uri",
+      "description": "Unique identifier for the credential"
+    },
+    "type": {
+      "type": ["string", "array"],
+      "description": "Credential type or types",
+      "items": {
+        "type": "string"
+      }
+    },
+    "issuer": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "type": "object",
+          "required": ["id"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uri"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ],
+      "description": "Entity that issued the credential"
+    },
+    "issuanceDate": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expirationDate": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "credentialSubject": {
+      "type": "object",
+      "required": ["agreement"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uri"
+        },
+        "agreement": {
+          "$ref": "../../core/agreement.schema.json"
+        }
+      },
+      "additionalProperties": true
+    },
+    "proof": {
+      "type": "object",
+      "required": ["type", "proofPurpose", "verificationMethod"],
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "proofPurpose": {
+          "type": "string"
+        },
+        "verificationMethod": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/profiles/vc/execution/input-verifiable-credential.schema.json
+++ b/schemas/profiles/vc/execution/input-verifiable-credential.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agreements.dev/schemas/profiles/vc/execution/input-verifiable-credential.schema.json",
+  "title": "Verifiable Credential Input",
+  "description": "Execution input describing an expected verifiable credential.",
+  "allOf": [
+    {
+      "$ref": "../../../core/execution/input.schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "format": {
+          "const": "vc/verifiable-credential"
+        },
+        "schemaRef": {
+          "const": "schemas/profiles/vc/execution/input-verifiable-credential.schema.json"
+        },
+        "constraints": {
+          "type": "object",
+          "properties": {
+            "issuer": {
+              "type": "string"
+            },
+            "subject": {
+              "type": "string"
+            },
+            "credentialType": {
+              "type": ["string", "array"],
+              "items": {
+                "type": "string"
+              }
+            },
+            "claims": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  ]
+}

--- a/templates/compositions/evm-eip712/grant-agreement.eip712.json
+++ b/templates/compositions/evm-eip712/grant-agreement.eip712.json
@@ -1,0 +1,267 @@
+{
+  "standard": {
+    "id": "agreements",
+    "coreVersion": "1.1.0-draft",
+    "profiles": [
+      {
+        "id": "evm",
+        "version": "1.0.0-draft"
+      },
+      {
+        "id": "eip712",
+        "version": "1.0.0-draft"
+      }
+    ]
+  },
+  "metadata": {
+    "id": "did:example:123456789abcdefghi",
+    "templateId": "did:template:grant-agreement-v1",
+    "version": "1.0.0",
+    "createdAt": "2024-03-20T12:00:00Z",
+    "name": "Grant Agreement",
+    "author": "Ecosystem Name Foundation",
+    "description": "Standard grant agreement for ecosystem development funding"
+  },
+  "variables": [
+    {
+      "id": "effectiveDate",
+      "type": "dateTime",
+      "name": "Effective Date",
+      "description": "The date when this agreement becomes effective",
+      "value": "",
+      "validation": {
+        "required": true,
+        "message": "Effective date is required"
+      }
+    },
+    {
+      "id": "foundationName",
+      "type": "string",
+      "name": "Foundation Name",
+      "description": "Legal name of the foundation entity",
+      "value": "Ecosystem Name Foundation",
+      "validation": {
+        "required": true,
+        "minLength": 3,
+        "message": "Foundation name is required"
+      }
+    },
+    {
+      "id": "jurisdiction",
+      "type": "string",
+      "name": "Jurisdiction",
+      "description": "Legal jurisdiction under which the foundation operates",
+      "value": "Jurisdiction",
+      "validation": {
+        "required": true,
+        "message": "Jurisdiction is required"
+      }
+    },
+    {
+      "id": "foundationAddress",
+      "type": "string",
+      "semanticType": "evm/address",
+      "name": "Foundation Address",
+      "description": "Blockchain address of the foundation",
+      "value": "0x123f6e75d1BE0ee699C7Eb67594FEbC14ab3AA78",
+      "validation": {
+        "required": true,
+        "pattern": "^0x[a-fA-F0-9]{40}$",
+        "message": "Invalid D3 address format"
+      }
+    },
+    {
+      "id": "grantRecipientName",
+      "type": "string",
+      "name": "Grant Recipient Name",
+      "description": "Full name of the grant recipient",
+      "value": "",
+      "validation": {
+        "required": true,
+        "minLength": 2,
+        "message": "Grant recipient name is required"
+      }
+    },
+    {
+      "id": "grantRecipientAddress",
+      "type": "string",
+      "semanticType": "evm/address",
+      "name": "Grant Recipient Address",
+      "description": "Blockchain address of the grant recipient",
+      "value": null,
+      "validation": {
+        "required": true,
+        "pattern": "^0x[a-fA-F0-9]{40}$",
+        "message": "Invalid D3 address format"
+      }
+    },
+    {
+      "id": "ecosystemName",
+      "type": "string",
+      "name": "Ecosystem Name",
+      "description": "Name of the blockchain ecosystem",
+      "value": "Ecosystem Name",
+      "validation": {
+        "required": true,
+        "message": "Ecosystem name is required"
+      }
+    },
+    {
+      "id": "workTokenName",
+      "type": "string",
+      "name": "Work Token Name",
+      "description": "Name of the ecosystem's native token",
+      "value": "WORK",
+      "validation": {
+        "required": true,
+        "message": "Token name is required"
+      }
+    },
+    {
+      "id": "tokenAllocatorName",
+      "type": "string",
+      "name": "Token Allocator Name",
+      "description": "Name of the person designated to allocate tokens",
+      "value": "",
+      "validation": {
+        "required": true,
+        "message": "Token allocator name is required"
+      }
+    },
+    {
+      "id": "tokenAllocatorAddress",
+      "type": "string",
+      "semanticType": "evm/address",
+      "name": "Token Allocator Address",
+      "description": "Blockchain address of the token allocator",
+      "value": null,
+      "validation": {
+        "required": true,
+        "pattern": "^0x[a-fA-F0-9]{40}$",
+        "message": "Invalid D3 address format"
+      }
+    },
+    {
+      "id": "rfpNumber",
+      "type": "string",
+      "name": "RFP Number",
+      "description": "Reference number for the Request for Proposal",
+      "value": "",
+      "validation": {
+        "required": true,
+        "pattern": "^WRFP-[0-9]+$",
+        "message": "RFP number must be in format WRFP-XXX"
+      }
+    },
+    {
+      "id": "rfpLink",
+      "type": "string",
+      "name": "RFP Link",
+      "description": "URL link to the Request for Proposal document",
+      "value": "",
+      "validation": {
+        "required": true,
+        "pattern": "^https?:\\/\\/.*",
+        "message": "Must be a valid URL"
+      }
+    },
+    {
+      "id": "grantAmount",
+      "type": "number",
+      "name": "Grant Amount",
+      "description": "Amount of tokens to be granted to the recipient",
+      "value": 0,
+      "validation": {
+        "required": true,
+        "min": 1,
+        "message": "Grant amount must be greater than zero"
+      }
+    }
+  ],
+  "content": {
+    "type": "md",
+    "data": "# **Grant Agreement**\n\nThis Grant Agreement (**\"Agreement\"**) is entered into on :variable{id=\"effectiveDate\"}, (the **:variable{id=\"effectiveDate\" property=\"name\"}**), between :variable{id=\"foundationName\"}, a :variable{id=\"jurisdiction\"} foundation company (the **:variable{id=\"foundationName\" property=\"name\"}**) with D3 address :variable{id=\"foundationAddress\"}, and :variable{id=\"grantRecipientName\"}, an individual with address :variable{id=\"grantRecipientAddress\"} (**:variable{id=\"grantRecipientName\" property=\"name\"}**).\n\nThe Foundation has been established, in part, to help promote growth of the :variable{id=\"ecosystemName\"} ecosystem and seeks to award grants to promote development consistent with the collective decision making of the :variable{id=\"workTokenName\"} token (**:variable{id=\"workTokenName\"}**) holder community (the **:variable{id=\"workTokenName\"} Community**).\n\nThe Grant Recipient has been selected by the Foundation Designated Token Allocator :variable{id=\"tokenAllocatorName\"} (**:variable{id=\"tokenAllocatorName\" property=\"name\"}**) with address :variable{id=\"tokenAllocatorAddress\"} to receive a grant subject and in accordance with the terms and conditions of this Agreement.\n\nTHEREFORE, the parties agree as follows:\n\n## **1. GRANT RECIPIENT ACTIVITIES**\n\n1.1 Grants. Foundation and Grant Recipient are entering into this Agreement in connection with RFP#: :variable{id=\"rfpNumber\"}, as set forth at :variable{id=\"rfpLink\"}, which describes the specific activities to be performed by Grant Recipient (the **\"Grant\"**).\n\n1.2 Performance of Grant Recipient Activities. Grant Recipient will perform the activities described in the Grant (the **\"Grant Recipient Activities\"**) in accordance with the terms and conditions set forth in each such Grant and this Agreement and with any applicable laws.\n\n## **2. GRANT DISTRIBUTION**\n\nThe Token Allocator will pay Grant Recipient on behalf of the Foundation the amount of :variable{id=\"grantAmount\"} :variable{id=\"workTokenName\"} tokens in accordance with the terms set forth in this agreement.\n\nIN WITNESS WHEREOF, the Grant Recipient has executed this Agreement on the date first written above.\n\nName: :variable{id=\"grantRecipientName\"}"
+  },
+  "execution": {
+    "type": "dfsm",
+    "data": {
+      "states": ["AWAITING_SIGNATURES", "ACTIVE_PENDING_REVIEW", "APPROVED", "REJECTED"],
+      "inputs": {
+        "grantRecipientSignature": {
+          "id": "grantRecipientSignature",
+          "format": "eip712/typed-data-signature",
+          "schemaRef": "schemas/compositions/evm-eip712/execution/input-eip712-attestation.schema.json",
+          "displayName": "Grant Recipient Signature",
+          "description": "EIP-712 typed-data signature from the grant recipient accepting the terms of the grant agreement",
+          "constraints": {
+            "signer": "${grantRecipientAddress}",
+            "signerSemanticType": "evm/address",
+            "payload": {
+              "isGrantRecipientApproved": true
+            }
+          }
+        },
+        "workApprovedSignature": {
+          "id": "workApprovedSignature",
+          "format": "eip712/typed-data-signature",
+          "schemaRef": "schemas/compositions/evm-eip712/execution/input-eip712-attestation.schema.json",
+          "displayName": "Work Approved Signature",
+          "description": "EIP-712 typed-data signature from the token allocator confirming that the grant work has been completed successfully",
+          "constraints": {
+            "signer": "${tokenAllocatorAddress}",
+            "signerSemanticType": "evm/address",
+            "payload": {
+              "isApproved": true
+            }
+          }
+        },
+        "workRejectedSignature": {
+          "id": "workRejectedSignature",
+          "format": "eip712/typed-data-signature",
+          "schemaRef": "schemas/compositions/evm-eip712/execution/input-eip712-attestation.schema.json",
+          "displayName": "Work Rejected Signature",
+          "description": "EIP-712 typed-data signature from the token allocator confirming that the grant work has been rejected",
+          "constraints": {
+            "signer": "${tokenAllocatorAddress}",
+            "signerSemanticType": "evm/address",
+            "payload": {
+              "isApproved": false
+            }
+          }
+        }
+      },
+      "transitions": [
+        {
+          "from": "AWAITING_SIGNATURES",
+          "to": "ACTIVE_PENDING_REVIEW",
+          "conditions": [
+            {
+              "type": "isValid",
+              "inputs": ["grantRecipientSignature"]
+            }
+          ]
+        },
+        {
+          "from": "ACTIVE_PENDING_REVIEW",
+          "to": "APPROVED",
+          "conditions": [
+            {
+              "type": "isValid",
+              "inputs": ["workApprovedSignature"]
+            }
+          ]
+        },
+        {
+          "from": "ACTIVE_PENDING_REVIEW",
+          "to": "REJECTED",
+          "conditions": [
+            {
+              "type": "isValid",
+              "inputs": ["workRejectedSignature"]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/templates/profiles/evm/grant-agreement.evm.json
+++ b/templates/profiles/evm/grant-agreement.evm.json
@@ -1,0 +1,181 @@
+{
+  "standard": {
+    "id": "agreements",
+    "coreVersion": "1.1.0-draft",
+    "profiles": [
+      {
+        "id": "evm",
+        "version": "1.0.0-draft"
+      }
+    ]
+  },
+  "metadata": {
+    "id": "did:example:123456789abcdefghi",
+    "templateId": "did:template:grant-agreement-v1",
+    "version": "1.0.0",
+    "createdAt": "2024-03-20T12:00:00Z",
+    "name": "Grant Agreement",
+    "author": "Ecosystem Name Foundation",
+    "description": "Standard grant agreement for ecosystem development funding"
+  },
+  "variables": [
+    {
+      "id": "effectiveDate",
+      "type": "dateTime",
+      "name": "Effective Date",
+      "description": "The date when this agreement becomes effective",
+      "value": "",
+      "validation": {
+        "required": true,
+        "message": "Effective date is required"
+      }
+    },
+    {
+      "id": "foundationName",
+      "type": "string",
+      "name": "Foundation Name",
+      "description": "Legal name of the foundation entity",
+      "value": "Ecosystem Name Foundation",
+      "validation": {
+        "required": true,
+        "minLength": 3,
+        "message": "Foundation name is required"
+      }
+    },
+    {
+      "id": "jurisdiction",
+      "type": "string",
+      "name": "Jurisdiction",
+      "description": "Legal jurisdiction under which the foundation operates",
+      "value": "Jurisdiction",
+      "validation": {
+        "required": true,
+        "message": "Jurisdiction is required"
+      }
+    },
+    {
+      "id": "foundationAddress",
+      "type": "string",
+      "semanticType": "evm/address",
+      "name": "Foundation Address",
+      "description": "Blockchain address of the foundation",
+      "value": "0x123f6e75d1BE0ee699C7Eb67594FEbC14ab3AA78",
+      "validation": {
+        "required": true,
+        "pattern": "^0x[a-fA-F0-9]{40}$",
+        "message": "Invalid D3 address format"
+      }
+    },
+    {
+      "id": "grantRecipientName",
+      "type": "string",
+      "name": "Grant Recipient Name",
+      "description": "Full name of the grant recipient",
+      "value": "",
+      "validation": {
+        "required": true,
+        "minLength": 2,
+        "message": "Grant recipient name is required"
+      }
+    },
+    {
+      "id": "grantRecipientAddress",
+      "type": "string",
+      "semanticType": "evm/address",
+      "name": "Grant Recipient Address",
+      "description": "Blockchain address of the grant recipient",
+      "value": null,
+      "validation": {
+        "required": true,
+        "pattern": "^0x[a-fA-F0-9]{40}$",
+        "message": "Invalid D3 address format"
+      }
+    },
+    {
+      "id": "ecosystemName",
+      "type": "string",
+      "name": "Ecosystem Name",
+      "description": "Name of the blockchain ecosystem",
+      "value": "Ecosystem Name",
+      "validation": {
+        "required": true,
+        "message": "Ecosystem name is required"
+      }
+    },
+    {
+      "id": "workTokenName",
+      "type": "string",
+      "name": "Work Token Name",
+      "description": "Name of the ecosystem's native token",
+      "value": "WORK",
+      "validation": {
+        "required": true,
+        "message": "Token name is required"
+      }
+    },
+    {
+      "id": "tokenAllocatorName",
+      "type": "string",
+      "name": "Token Allocator Name",
+      "description": "Name of the person designated to allocate tokens",
+      "value": "",
+      "validation": {
+        "required": true,
+        "message": "Token allocator name is required"
+      }
+    },
+    {
+      "id": "tokenAllocatorAddress",
+      "type": "string",
+      "semanticType": "evm/address",
+      "name": "Token Allocator Address",
+      "description": "Blockchain address of the token allocator",
+      "value": null,
+      "validation": {
+        "required": true,
+        "pattern": "^0x[a-fA-F0-9]{40}$",
+        "message": "Invalid D3 address format"
+      }
+    },
+    {
+      "id": "rfpNumber",
+      "type": "string",
+      "name": "RFP Number",
+      "description": "Reference number for the Request for Proposal",
+      "value": "",
+      "validation": {
+        "required": true,
+        "pattern": "^WRFP-[0-9]+$",
+        "message": "RFP number must be in format WRFP-XXX"
+      }
+    },
+    {
+      "id": "rfpLink",
+      "type": "string",
+      "name": "RFP Link",
+      "description": "URL link to the Request for Proposal document",
+      "value": "",
+      "validation": {
+        "required": true,
+        "pattern": "^https?:\\/\\/.*",
+        "message": "Must be a valid URL"
+      }
+    },
+    {
+      "id": "grantAmount",
+      "type": "number",
+      "name": "Grant Amount",
+      "description": "Amount of tokens to be granted to the recipient",
+      "value": 0,
+      "validation": {
+        "required": true,
+        "min": 1,
+        "message": "Grant amount must be greater than zero"
+      }
+    }
+  ],
+  "content": {
+    "type": "md",
+    "data": "# **Grant Agreement**\n\nThis Grant Agreement (**\"Agreement\"**) is entered into on :variable{id=\"effectiveDate\"}, (the **:variable{id=\"effectiveDate\" property=\"name\"}**), between :variable{id=\"foundationName\"}, a :variable{id=\"jurisdiction\"} foundation company (the **:variable{id=\"foundationName\" property=\"name\"}**) with D3 address :variable{id=\"foundationAddress\"}, and :variable{id=\"grantRecipientName\"}, an individual with address :variable{id=\"grantRecipientAddress\"} (**:variable{id=\"grantRecipientName\" property=\"name\"}**).\n\nThe Foundation has been established, in part, to help promote growth of the :variable{id=\"ecosystemName\"} ecosystem and seeks to award grants to promote development consistent with the collective decision making of the :variable{id=\"workTokenName\"} token (**:variable{id=\"workTokenName\"}**) holder community (the **:variable{id=\"workTokenName\"} Community**).\n\nThe Grant Recipient has been selected by the Foundation Designated Token Allocator :variable{id=\"tokenAllocatorName\"} (**:variable{id=\"tokenAllocatorName\" property=\"name\"}**) with address :variable{id=\"tokenAllocatorAddress\"} to receive a grant subject and in accordance with the terms and conditions of this Agreement.\n\nTHEREFORE, the parties agree as follows:\n\n## **1. GRANT RECIPIENT ACTIVITIES**\n\n1.1 Grants. Foundation and Grant Recipient are entering into this Agreement in connection with RFP#: :variable{id=\"rfpNumber\"}, as set forth at :variable{id=\"rfpLink\"}, which describes the specific activities to be performed by Grant Recipient (the **\"Grant\"**).\n\n1.2 Performance of Grant Recipient Activities. Grant Recipient will perform the activities described in the Grant (the **\"Grant Recipient Activities\"**) in accordance with the terms and conditions set forth in each such Grant and this Agreement and with any applicable laws.\n\n## **2. GRANT DISTRIBUTION**\n\nThe Token Allocator will pay Grant Recipient on behalf of the Foundation the amount of :variable{id=\"grantAmount\"} :variable{id=\"workTokenName\"} tokens in accordance with the terms set forth in this agreement.\n\nIN WITNESS WHEREOF, the Grant Recipient has executed this Agreement on the date first written above.\n\nName: :variable{id=\"grantRecipientName\"}"
+  }
+}


### PR DESCRIPTION
## Summary
- add drafted core schemas plus standalone `evm`, `vc`, and `eip712` profile schemas
- add explicit composition schemas for `evm + eip712`, `vc + eip712`, and `evm + vc + eip712`
- split the grant example into a pure `evm` template and an `evm + eip712` execution example

## Validation
- JSON parse checks passed for new schema and template files
- targeted structural checks passed for the pure `evm` and `evm + eip712` examples
- full JSON Schema validation not run because `jsonschema`/`ajv` is not installed in the workspace