### PR TITLE
(3/3) Port repo docs and canonical examples to composable profiles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,8 @@ When contributing to the current draft model, prefer these directories:
 
 Root-level `schemas/*.json` and `templates/*.json` files are retained as legacy reference material and should not be treated as the canonical target for new work unless the change is explicitly about legacy compatibility.
 
+The canonical schema directories are also npm workspace packages. If you change package manifests, exports, or canonical files, run `npm run verify:modules`.
+
 ## IP State Expectations
 
 ### `IDEA`
@@ -53,6 +55,7 @@ The PR should include:
 - If your change affects one concern only, update the relevant profile under `schemas/profiles/`
 - If your change combines concerns, prefer an explicit composition schema under `schemas/compositions/`
 - Add or update example documents under the matching `templates/` directory
+- Keep the workspace package exports in sync with the canonical files they publish
 
 ## Legacy Note
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,59 @@
-# Grant Agreement Protocol
+# Agreements Protocol Contributing Guide
 
 ## IP PR Guidelines
 
-An IP (Improvement Proposal) is a proposed change to the protocol. In order to be fully integrated into the protocol, currently the protocol team votes on the over approval, and the following process must be followed.
+An IP (Improvement Proposal) is a proposed change to the protocol.
 
-IP currently have two statuses:
-* `IDEA` - budding concept
-* `DRAFT` - a proposal that is not yet ready for review
-* `PROPOSED` - a proposal that is ready for review
-* `ACCEPTED` - a proposal that has been accepted and integrated into the protocol
+IP statuses:
 
-IP state PR requirements:
-* `IDEA`: a PR to the [README.md](README.me) file proposing it to be added to the list of IPs that might become drafter
-* `IDEA -> DRAFT`: a simple markdown file in the [definition](definition) directory. At this point your IP will get an assigned number.
-* `DRAFT -> PROPOSED`: a PR that includes the following:
-  * the IP markdown file
-  * modified [PROTOCOL.md](PROTOCOL.md) to include the new IP
-  * modified [templates json file](templates/grant-agreement.json) to showcase exact changes to the JSON template
-  * modified [templates description file](templates/grant-agreement.md) to showcase the changes to the prose
-* `PROPOSED -> ACCEPTED`: a vote by the protocol team to accept the proposal and merge the PROPOSED PR
+- `IDEA` - budding concept
+- `DRAFT` - proposal under active development
+- `PROPOSED` - proposal ready for review
+- `ACCEPTED` - proposal accepted and merged
 
+## Canonical Repo Layout
 
+When contributing to the current draft model, prefer these directories:
 
+- `schemas/core/`
+- `schemas/profiles/`
+- `schemas/compositions/`
+- `templates/core/`
+- `templates/profiles/`
+- `templates/compositions/`
 
+Root-level `schemas/*.json` and `templates/*.json` files are retained as legacy reference material and should not be treated as the canonical target for new work unless the change is explicitly about legacy compatibility.
 
+## IP State Expectations
+
+### `IDEA`
+
+- Open a PR updating [README.md](./README.md) to add the proposed topic to the active IP list or roadmap discussion
+
+### `IDEA -> DRAFT`
+
+- Add a new markdown file under [improvement-proposals](./improvement-proposals)
+
+### `DRAFT -> PROPOSED`
+
+The PR should include:
+
+- the IP markdown file
+- the relevant canonical schemas under [schemas](./schemas)
+- the relevant canonical examples under [templates](./templates)
+- README updates if the public repo shape or entry points changed
+
+### `PROPOSED -> ACCEPTED`
+
+- protocol team review and acceptance
+
+## Practical Guidance
+
+- If your change affects the core document model, update `schemas/core/`
+- If your change affects one concern only, update the relevant profile under `schemas/profiles/`
+- If your change combines concerns, prefer an explicit composition schema under `schemas/compositions/`
+- Add or update example documents under the matching `templates/` directory
+
+## Legacy Note
+
+If you need to touch the legacy root-level schemas or templates, call that out explicitly in the PR description so reviewers know the change is intentional.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Agreements Protocol Contributing Guide
+# Agreements Standard Contributing Guide
 
 ## IP PR Guidelines
 
-An IP (Improvement Proposal) is a proposed change to the protocol.
+An IP (Improvement Proposal) is a proposed change to the standard.
 
 IP statuses:
 
@@ -45,7 +45,7 @@ The PR should include:
 
 ### `PROPOSED -> ACCEPTED`
 
-- protocol team review and acceptance
+- maintainer review and acceptance
 
 ## Practical Guidance
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,45 @@ More detail:
 - [Schemas directory guide](./schemas/README.md)
 - [Templates directory guide](./templates/README.md)
 
+## Workspace Modules
+
+The canonical schema trees are now also modeled as npm workspace modules:
+
+- `@agreements-standard/core`
+- `@agreements-standard/profile-evm`
+- `@agreements-standard/profile-vc`
+- `@agreements-standard/profile-eip712`
+- `@agreements-standard/composition-evm-eip712`
+- `@agreements-standard/composition-vc-eip712`
+- `@agreements-standard/composition-evm-vc-eip712`
+- `@agreements-standard/fixtures`
+
+This keeps the schema source-of-truth in the repo while giving implementations a package boundary they can depend on directly. The canonical schema files remain under `schemas/`, and the canonical example documents remain under `templates/`.
+
+## Versioning and Verification
+
+Versioning is split by concern:
+
+- documents declare `standard.coreVersion` and explicit profile versions
+- `@agreements-standard/core` tracks the core schema version
+- profile and composition packages track their own schema versions
+- implementations should declare the package version ranges they support and reject incompatible documents
+
+The root workspace includes a package verification script:
+
+```bash
+npm run verify:modules
+```
+
+That script checks the module graph for:
+
+- workspace package coverage of the canonical schema/template trees
+- package export coverage for every canonical file
+- dependency/version consistency between modules
+- fixtures manifest consistency with the exported canonical examples
+
+This is the first line of defense against future drift between the standard and the implementation layer.
+
 ## Legacy Files
 
 The following root-level files are retained as pre-IP-005 reference material while the composable profile model is still in draft:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Agreements Protocol
+# Agreements Standard
 
 [![JSON Schema](https://img.shields.io/badge/schema-JSON-blue)](./schemas/core/agreement.schema.json)
 
-The Agreements Protocol is a JSON-based standard for authoring, validating, and executing structured agreements.
+The Agreements Standard is a JSON-based standard for authoring, validating, and executing structured agreements.
 
 The current repo is organized around a chain-neutral core plus composable profiles:
 

--- a/README.md
+++ b/README.md
@@ -256,14 +256,14 @@ More detail:
 
 The canonical schema trees are now also modeled as npm workspace modules:
 
-- `@cns/agreements-core`
-- `@cns/agreements-profile-evm`
-- `@cns/agreements-profile-vc`
-- `@cns/agreements-profile-eip712`
-- `@cns/agreements-composition-evm-eip712`
-- `@cns/agreements-composition-vc-eip712`
-- `@cns/agreements-composition-evm-vc-eip712`
-- `@cns/agreements-fixtures`
+- `@cns-labs/agreements-core`
+- `@cns-labs/agreements-profile-evm`
+- `@cns-labs/agreements-profile-vc`
+- `@cns-labs/agreements-profile-eip712`
+- `@cns-labs/agreements-composition-evm-eip712`
+- `@cns-labs/agreements-composition-vc-eip712`
+- `@cns-labs/agreements-composition-evm-vc-eip712`
+- `@cns-labs/agreements-fixtures`
 
 This keeps the schema source-of-truth in the repo while giving implementations a package boundary they can depend on directly. The canonical schema files remain under `schemas/`, and the canonical example documents remain under `templates/`.
 
@@ -272,7 +272,7 @@ This keeps the schema source-of-truth in the repo while giving implementations a
 Versioning is split by concern:
 
 - documents declare `standard.coreVersion` and explicit profile versions
-- `@cns/agreements-core` tracks the core schema version
+- `@cns-labs/agreements-core` tracks the core schema version
 - profile and composition packages track their own schema versions
 - implementations should declare the package version ranges they support and reject incompatible documents
 

--- a/README.md
+++ b/README.md
@@ -1,891 +1,274 @@
 # Agreements Protocol
 
-[![JSON Schema](https://img.shields.io/badge/schema-JSON-blue)](./schemas/template.schema.json)
+[![JSON Schema](https://img.shields.io/badge/schema-JSON-blue)](./schemas/core/agreement.schema.json)
 
-The Agreements Protocol is a JSON-based standard for creating and executing legally binding web3/blockchain agreements. Think of it as "DocuSign for web3" - providing a standardized way to create, validate, and execute digital agreements with blockchain-based proofs and state transitions.
+The Agreements Protocol is a JSON-based standard for authoring, validating, and executing structured agreements.
 
-## Protocol Overview
+The current repo is organized around a chain-neutral core plus composable profiles:
 
-The protocol consists of five core components:
+- `core` for the base agreement document model
+- `evm` for EVM runtime and value semantics
+- `vc` for Verifiable Credential envelope semantics
+- `eip712` for typed-data proof semantics
+- `compositions/*` for explicit combinations of those concerns
 
-1. **[Metadata](#1-metadata)** - Agreement identification and context
-2. **[Variables](#2-variables)** - Typed inputs that drive the agreement
-3. **[Content](#3-content)** - Legal prose with variable interpolation
-4. **[Execution Flow](#4-execution-flow)** - State machine for agreement progression, driven via verifiable inputs (transaction receipts, ZK proofs, VCs)
-5. **[Template](#5-template)** - Complete template structure
-6. **[Verifiable Credential Wrapper](#6-verifiable-credential-wrapper)** - Wrapping agreements in W3C Verifiable Credentials
-
-[View Full Schema Definition →](./schemas/template.schema.json)
-
-### Current Status
+## Current Status
 
 - 🚧 **[IP-001](./improvement-proposals/IP-001.md)**: DFSM to ASM
 - ✅ **[IP-002](./improvement-proposals/IP-002.md)**: MDAST Content Representation
-- 🚧 **[IP-003](https://github.com/ConsenSysMesh/agreements-protocol/pull/16)**: Proofs and Execution Flow specifications
+- 🚧 **[IP-003](https://github.com/CNSLabs/agreements-standard/pull/16)**: Proofs and Execution Flow specifications
 - ✅ **[IP-004](./improvement-proposals/IP-004.md)**: Standardized Metadata, Flat Variables, Schemas, and Content Types
 - 🚧 **[IP-005](./improvement-proposals/IP-005.md)**: Core JSON standard plus composable profiles
 
-#### Planned
+## Canonical Model
 
-- VC Schema Standards
-- DID Method Extensions
+### 1. Core Agreement Document
 
-## Core Components
+The canonical agreement document is defined by:
 
-To illustrate how the Agreements Protocol works, let's start with a simple example of a written agreement:
+- [Core agreement schema](./schemas/core/agreement.schema.json)
+- [Core metadata schema](./schemas/core/metadata.schema.json)
+- [Core variables schema](./schemas/core/variables.schema.json)
+- [Core content schema](./schemas/core/content.schema.json)
+- [Core MDAST schema](./schemas/core/mdast.schema.json)
+- [Core DFSM schema](./schemas/core/execution/dfsm.schema.json)
+- [Core execution input schema](./schemas/core/execution/input.schema.json)
 
-```md
-# Agreement
+Core documents define:
 
-I, Jane Doe, agree to provide [PartyB] with one hour of startup business advice.
+- `standard`
+- `metadata`
+- `variables`
+- `content`
+- optional `execution`
 
-In exchange, [PartyB] agrees to transfer [Amount] USDC to my Ethereum address: 0x123...abcd on the Ethereum mainnet.
-
-**Signature:** Jane Doe
-**Ethereum Address:** 0x123...abcd
-
-**Signature:** [PartyB]
-**Ethereum Address:** [PartyBAddress]
-```
-
-This simple consulting agreement contains all the key elements we need to demonstrate how the protocol works. In the following sections, we'll break down how each component of this agreement maps to our protocol schema:
-
-1. **Metadata** - How we identify and version this agreement
-2. **Variables** - The dynamic inputs (`[PartyB]`, `[Amount]`, `[PartyBAddress]`)
-3. **Content** - The agreement text with variable interpolation
-4. **Execution Flow** - The signing and verification process
-
-Let's examine each component in detail:
-
-### 1. Metadata
-
-Agreement metadata provides essential identification and context:
-
-**Schema Definition:**
+Draft shape:
 
 ```json
 {
-  "metadata": {
-    "type": "object",
-    "required": ["id", "templateId", "version", "createdAt", "name", "author", "description"],
-    "properties": {
-      "id": {
-        "type": "string",
-        "pattern": "^did:.*",
-        "description": "Unique identifier for the agreement instance"
-      },
-      "templateId": {
-        "type": "string",
-        "pattern": "^did:template:.*",
-        "description": "Identifier for the template type"
-      }
-    }
-  }
+  "standard": {
+    "id": "agreements",
+    "coreVersion": "1.1.0-draft",
+    "profiles": []
+  },
+  "metadata": {},
+  "variables": [],
+  "content": {}
 }
 ```
 
-**Example Usage:**
+### 2. Profiles
+
+Profiles refine the core without changing the encoding. A profile is declared in `standard.profiles`.
+
+#### `evm`
+
+The `evm` profile owns EVM-specific runtime and value semantics:
+
+- `semanticType: "evm/address"`
+- EVM transaction receipt constraints
+- chain-bound runtime semantics
+
+Canonical files:
+
+- [EVM agreement schema](./schemas/profiles/evm/agreement.schema.json)
+- [EVM address semantic schema](./schemas/profiles/evm/variables/evm-address.semantic.schema.json)
+- [EVM transaction receipt input schema](./schemas/profiles/evm/execution/input-transaction-receipt.schema.json)
+
+#### `vc`
+
+The `vc` profile owns Verifiable Credential envelope structure:
+
+- VC `@context`, `type`, `issuer`, `credentialSubject`, and `proof`
+- agreement-wrapping rules
+- generic VC-oriented proof carriage
+
+Canonical files:
+
+- [VC agreement envelope schema](./schemas/profiles/vc/agreement-envelope.schema.json)
+- [VC execution input schema](./schemas/profiles/vc/execution/input-verifiable-credential.schema.json)
+
+#### `eip712`
+
+The `eip712` profile owns typed-data proof semantics:
+
+- domain structure
+- type definitions
+- primary type
+- proof encoding
+
+Canonical files:
+
+- [EIP-712 agreement schema](./schemas/profiles/eip712/agreement.schema.json)
+- [EIP-712 typed-data input schema](./schemas/profiles/eip712/execution/input-typed-data-signature.schema.json)
+- [EIP-712 proof schema](./schemas/profiles/eip712/proofs/typed-data-proof.schema.json)
+
+### 3. Explicit Compositions
+
+Combinations of concerns are modeled explicitly under `schemas/compositions/`.
+
+Canonical composition schemas in this repo:
+
+- [EVM + EIP-712 agreement schema](./schemas/compositions/evm-eip712/agreement.schema.json)
+- [EVM + EIP-712 input schema](./schemas/compositions/evm-eip712/execution/input-eip712-attestation.schema.json)
+- [VC + EIP-712 envelope schema](./schemas/compositions/vc-eip712/agreement-envelope.schema.json)
+- [EVM + VC + EIP-712 envelope schema](./schemas/compositions/evm-vc-eip712/agreement-envelope.schema.json)
+
+This means:
+
+- a VC envelope signed using EIP-712 is modeled as `vc + eip712`
+- an EVM agreement executed via EIP-712 signatures is modeled as `evm + eip712`
+- a wrapped EVM agreement with an EIP-712 VC proof is modeled as `evm + vc + eip712`
+
+## Core Concepts
+
+### Metadata
+
+Metadata identifies and versions the agreement payload.
 
 ```json
 {
   "metadata": {
-    "id": "did:example:123",
-    "templateId": "did:template:consulting-v1",
+    "id": "did:example:consulting-core-1",
+    "templateId": "did:template:consulting-core-v1",
     "version": "1.0.0",
     "createdAt": "2024-03-20T12:00:00Z",
-    "name": "Consulting Agreement Template",
-    "author": "Jane Doe",
-    "description": "Standard template for one-hour consulting services with USDC payment"
+    "name": "Consulting Agreement",
+    "author": "Example Author",
+    "description": "Simple consulting agreement"
   }
 }
 ```
 
-[View full schema →](./schemas/template.schema.json#metadata)
+### Variables
 
-### 2. Variables
-
-Variables define typed inputs that can be referenced throughout the agreement:
-
-**Schema Definition:**
+Core variables use primitive types and optional profile semantics.
 
 ```json
 {
-  "variables": {
-    "type": "array",
-    "items": {
-      "type": "object",
-      "required": ["id", "type", "name", "description"],
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Unique identifier for the variable"
-        },
-        "type": {
-          "type": "string",
-          "enum": ["string", "number", "address", "dateTime"],
-          "description": "Data type of the variable"
-        },
-        "validation": {
-          "type": "object",
-          "properties": {
-            "required": { "type": "boolean" },
-            "min": { "type": "number" },
-            "max": { "type": "number" },
-            "pattern": { "type": "string", "format": "regex" }
-          }
-        }
-      }
-    }
+  "id": "grantRecipientAddress",
+  "type": "string",
+  "semanticType": "evm/address",
+  "name": "Grant Recipient Address",
+  "description": "Address of the grant recipient",
+  "validation": {
+    "required": true,
+    "pattern": "^0x[a-fA-F0-9]{40}$"
   }
 }
 ```
 
-**Example Usage:**
+### Content
 
-```json
-{
-  "variables": [
-    {
-      "id": "partyB",
-      "type": "string",
-      "name": "Party B",
-      "description": "Name of the party receiving consulting services",
-      "validation": {
-        "required": true,
-        "minLength": 1
-      }
-    },
-    {
-      "id": "amount",
-      "type": "number",
-      "name": "USDC Amount",
-      "description": "Amount of USDC to be paid for services",
-      "validation": {
-        "required": true,
-        "min": 1
-      }
-    },
-    {
-      "id": "partyBAddress",
-      "type": "address",
-      "name": "Party B Ethereum Address",
-      "description": "Ethereum address of Party B",
-      "validation": {
-        "required": true,
-        "pattern": "^0x[a-fA-F0-9]{40}$"
-      }
-    }
-  ]
-}
-```
+Content remains JSON-based and supports:
 
-#### Variable Usage
+- `md`
+- `mdast`
 
-Variables can be referenced in three different formats:
+The canonical custom content node is `variable`. The core model does not define an `address` node.
 
-1. **MDAST Format**
-
-```json
-{
-  "type": "variable",
-  "id": "partyB"
-}
-```
-
-To reference specific properties:
-
-```json
-{
-  "type": "variable",
-  "id": "partyB",
-  "property": "name"
-}
-```
-
-2. **Markdown Format**
+Markdown example:
 
 ```md
-:variable{id='partyB'}
-:variable{id='partyB' property='name'}
-:variable{id='partyB' property='description'}
+:variable{id='clientName'}
+:variable{id='grantRecipientAddress'}
 ```
 
-3. **JSON Template Format**
+### Execution
+
+The core execution model is format-agnostic. Inputs describe:
+
+- `format`
+- `schemaRef`
+- `displayName`
+- `description`
+- `constraints`
+
+Example:
 
 ```json
 {
-  "client": "${partyB}",
-  "clientName": "${partyB.name}",
-  "paymentAmount": "${amount}"
-}
-```
-
-[View full schema →](./schemas/template.schema.json#variables)
-
-### 3. Content
-
-Agreement content supports multiple formats with variable interpolation:
-
-**Schema Definition:**
-
-```json
-{
-  "content": {
-    "type": "object",
-    "required": ["type", "data"],
-    "properties": {
-      "type": {
-        "type": "string",
-        "enum": ["mdast", "md"],
-        "description": "Content format type"
-      },
-      "data": {
-        "oneOf": [
-          {
-            "if": { "properties": { "type": { "const": "mdast" } } },
-            "then": { "$ref": "mdast.schema.json" }
-          },
-          {
-            "if": { "properties": { "type": { "const": "md" } } },
-            "then": { "type": "string" }
-          }
-        ]
-      }
+  "id": "grantRecipientAcceptance",
+  "format": "eip712/typed-data-signature",
+  "schemaRef": "schemas/profiles/eip712/execution/input-typed-data-signature.schema.json",
+  "displayName": "Grant Recipient Signature",
+  "description": "Grant recipient acceptance attestation",
+  "constraints": {
+    "signer": "${grantRecipientAddress}",
+    "payload": {
+      "hasAcceptedTerms": true
     }
   }
 }
 ```
 
-**Markdown Example:**
-```json
-{
-  "content": {
-    "type": "md",
-    "data": "# Agreement\n\nI, Jane Doe, agree to provide :variable{id='partyB'} with one hour of startup business advice.\n\nIn exchange, :variable{id='partyB'} agrees to transfer :variable{id='amount'} USDC to my Ethereum address: 0x123...abcd on the Ethereum mainnet.\n\n**Signature:** Jane Doe\n**Ethereum Address:** 0x123...abcd\n\n**Signature:** :variable{id='partyB'}\n**Ethereum Address:** :variable{id='partyBAddress'}"
-  }
-}
+## Example Documents
+
+### Core
+
+- [Consulting agreement (core)](./templates/core/consulting-agreement.core.json)
+
+### Profiles
+
+- [Grant agreement (evm)](./templates/profiles/evm/grant-agreement.evm.json)
+- [Grant agreement (evm, mdast)](./templates/profiles/evm/grant-agreement.evm.mdast.json)
+- [Consulting agreement envelope (vc)](./templates/profiles/vc/consulting-agreement.vc.json)
+
+### Compositions
+
+- [Grant agreement with EVM + EIP-712 execution](./templates/compositions/evm-eip712/grant-agreement.eip712.json)
+- [Consulting agreement with VC + EIP-712 envelope](./templates/compositions/vc-eip712/consulting-agreement.vc-eip712.json)
+- [Grant agreement with EVM + VC + EIP-712 envelope](./templates/compositions/evm-vc-eip712/grant-agreement.vc-eip712.json)
+
+## Repo Layout
+
+```text
+schemas/
+  core/
+  profiles/
+    evm/
+    vc/
+    eip712/
+  compositions/
+    evm-eip712/
+    vc-eip712/
+    evm-vc-eip712/
+
+templates/
+  core/
+  profiles/
+    evm/
+    vc/
+  compositions/
+    evm-eip712/
+    vc-eip712/
+    evm-vc-eip712/
+
+improvement-proposals/
 ```
 
-**MDAST Example:**
+More detail:
 
-```json
-{
-  "content": {
-    "type": "mdast",
-    "data": {
-      "type": "root",
-      "children": [
-        {
-          "type": "heading",
-          "depth": 1,
-          "children": [
-            {
-              "type": "text",
-              "value": "Agreement"
-            }
-          ]
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "I, Jane Doe, agree to provide "
-            },
-            {
-              "type": "variable",
-              "id": "partyB"
-            },
-            {
-              "type": "text",
-              "value": " with one hour of startup business advice."
-            }
-          ]
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "text",
-              "value": "In exchange, "
-            },
-            {
-              "type": "variable",
-              "id": "partyB"
-            },
-            {
-              "type": "text",
-              "value": " agrees to transfer "
-            },
-            {
-              "type": "variable",
-              "id": "amount"
-            },
-            {
-              "type": "text",
-              "value": " USDC to my Ethereum address: 0x123...abcd on the Ethereum mainnet."
-            }
-          ]
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "strong",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "Signature:"
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "value": " Jane Doe\n"
-            },
-            {
-              "type": "strong",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "Ethereum Address:"
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "value": " 0x123...abcd"
-            }
-          ]
-        },
-        {
-          "type": "paragraph",
-          "children": [
-            {
-              "type": "strong",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "Signature:"
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "value": " "
-            },
-            {
-              "type": "variable",
-              "id": "partyB"
-            },
-            {
-              "type": "text",
-              "value": "\n"
-            },
-            {
-              "type": "strong",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "Ethereum Address:"
-                }
-              ]
-            },
-            {
-              "type": "text",
-              "value": " "
-            },
-            {
-              "type": "variable",
-              "id": "partyBAddress"
-            }
-          ]
-        },
-      ]
-    }
-  }
-}
-```
+- [Schemas directory guide](./schemas/README.md)
+- [Templates directory guide](./templates/README.md)
 
-#### Content Formats
+## Legacy Files
 
-- **MDAST (Markdown Abstract Syntax Tree)**
+The following root-level files are retained as pre-IP-005 reference material while the composable profile model is still in draft:
 
-  - Structured content with rich semantic information
-  - [MDAST Specification](https://github.com/syntax-tree/mdast)
-  - [Unist Specification](https://github.com/syntax-tree/unist) (MDAST's foundation)
-  - [remark](https://github.com/remarkjs/remark) - Markdown processor powered by plugins
-  - [IP-002](./improvement-proposals/IP-002.md) - Our MDAST implementation details
-- **Markdown (MD)**
+- `schemas/template.schema.json`
+- `schemas/execution-dfsm.schema.json`
+- `schemas/mdast.schema.json`
+- `schemas/verified-credential-eip712.schema.json`
+- `templates/grant-agreement.json`
+- `templates/grant-agreement.md.json`
+- `templates/grant-agreement.md.dfsm.json`
+- `templates/grant-agreement-vc-wrapped.json`
+- `templates/grant-agreement.md`
+- `templates/grant-agreement.md.dfsm.json.md`
 
-  - Human-readable authoring format
-  - [CommonMark Spec](https://commonmark.org/) - Our supported Markdown syntax
-  - [GitHub Markdown Guide](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)
-  - Supports [remark-directive](https://github.com/remarkjs/remark-directive) syntax for variables
-
-### 4. Execution Flow
-
-
-Models the expected execution of the agreement. Various models could be used in the future, but for now a DFSM (Deterministic Finite State Machine) is considered, with future upgrades to an [ASM possible](./improvement-proposals/IP-001.md). The key characteristic of the DFSM model is that the state machine is expected to be driven by verifiable (provable) inputs provided.
-
-**Schema Definition:**
-
-```json
-{
-  "execution": {
-    "type": "object",
-    "description": "Execution model definition for agreement processing",
-    "required": ["type", "data"],
-    "properties": {
-      "type": {
-        "type": "string",
-        "description": "The type of execution model being used",
-        "enum": ["dfsm"]
-      },
-      "data": {
-        "type": "object",
-        "description": "The execution model data specific to the type",
-        "oneOf": [
-          {
-            "if": {
-              "properties": { "type": { "const": "dfsm" } },
-              "required": ["type"]
-            },
-            "then": {
-              "$ref": "execution-dfsm.schema.json"
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-```
-
-[View full DFSM schema →](./schemas/execution-dfsm.schema.json)
-
-#### States
-
-States represent the possible lifecycle stages of an agreement:
-
-**Schema Definition:**
-```json
-{
-  "states": {
-    "type": "array",
-    "description": "List of possible states for the agreement",
-    "items": {
-      "type": "string"
-    }
-  }
-}
-```
-
-**Example Usage:**
-```json
-{
-  "states": [
-    "PENDING_SIGNATURE",
-    "SIGNED"
-  ]
-}
-```
-
-#### Inputs
-
-Inputs represent verifiable data used to trigger state transitions:
-
-**Schema Definition:**
-```json
-{
-  "inputs": {
-    "type": "object",
-    "description": "Input definitions that can be used in transitions",
-    "additionalProperties": {
-      "type": "object",
-      "required": ["id", "type", "displayName", "description"],
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Unique identifier for the input"
-        },
-        "type": {
-          "type": "string",
-          "description": "Type of the input (e.g., VerifiedCredentialEIP712)"
-        },
-        "schema": {
-          "type": "string",
-          "enum": ["verified-credential-eip712.schema.json"],
-          "description": "JSON schema reference for the input type"
-        },
-        "displayName": {
-          "type": "string",
-          "description": "Human-readable name for the input"
-        },
-        "description": {
-          "type": "string",
-          "description": "Description of the input's purpose"
-        },
-        "value": {
-          "type": "object",
-          "description": "Required field values for the credentialSubject"
-        },
-        "signer": {
-          "type": "string",
-          "description": "Party that should sign this input"
-        }
-      }
-    }
-  }
-}
-```
-
-**Example Usage:**
-```json
-{
-  "inputs": {
-    "partyBSignature": {
-      "id": "partyBSignature",
-      "type": "VerifiedCredentialEIP712",
-      "schema": "verified-credential-eip712.schema.json",
-      "displayName": "Party B Signature",
-      "description": "EIP712 signature from Party B accepting the agreement terms",
-      "value": {
-        "hasAcceptedTerms": true
-      },
-      "signer": "${partyBAddress}"
-    }
-  }
-}
-```
-
-Inputs represent verifiable data used to trigger state transitions:
-
-- **Verifiable Credentials with EIP-712 Signatures**:
-  - W3C Verifiable Credentials with Ethereum's typed structured data signing (EIP-712)
-  - Includes standard VC properties like issuer, issuanceDate, and credentialSubject
-  - EIP-712 proof with domain, types, and signature
-  - [View full schema →](./schemas/verified-credential-eip712.schema.json)
-
-- **EVM Transaction Receipts** (🚧 as part of [IP-003](https://github.com/ConsenSysMesh/agreements-protocol/pull/7)):
-  - Transaction hash verification
-  - Event log verification
-  - Smart contract state verification
-
-- **Zero-Knowledge Proofs** (🚧):
-  - Planned support for zk-SNARKs and zk-STARKs
-  - Privacy-preserving verification
-
-#### Transitions
-
-Transitions define how an agreement moves between states:
-
-**Schema Definition:**
-```json
-{
-  "transitions": {
-    "type": "array",
-    "description": "State transitions with conditions",
-    "items": {
-      "type": "object",
-      "required": ["from", "to", "conditions"],
-      "properties": {
-        "from": {
-          "type": "string",
-          "description": "Starting state of the transition"
-        },
-        "to": {
-          "type": "string",
-          "description": "Ending state of the transition"
-        },
-        "conditions": {
-          "type": "array",
-          "description": "Conditions that must be met for the transition to occur",
-          "items": {
-            "type": "object",
-            "required": ["type"],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["isValid"],
-                "description": "Type of condition"
-              },
-              "inputs": {
-                "type": "array",
-                "description": "Input identifiers to evaluate",
-                "items": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-**Example Usage:**
-```json
-{
-  "transitions": [
-    {
-      "from": "PENDING_SIGNATURE",
-      "to": "SIGNED",
-      "conditions": [
-        {
-          "type": "isValid",
-          "inputs": ["partyBSignature"]
-        }
-      ]
-    }
-  ]
-}
-```
-
-The execution model ensures that agreements follow a predictable lifecycle based on verifiable proofs, making them suitable for legal and blockchain-based applications where cryptographic certainty is required.
-
-### 5. Template
-
-The complete template structure combines all components into a single JSON document:
-
-**Schema Definition:**
-
-```json
-{
-  "type": "object",
-  "required": ["metadata", "variables", "content"],
-  "properties": {
-    "metadata": {
-      "type": "object",
-      "required": ["id", "templateId", "version", "createdAt", "name", "author", "description"]
-    },
-    "variables": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["id", "type", "name", "description"]
-      }
-    },
-    "content": {
-      "type": "object",
-      "required": ["type", "data"],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["mdast", "md"]
-        }
-      }
-    },
-    "execution": {
-      "type": "object",
-      "required": ["type", "data"],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["dfsm"]
-        }
-      }
-    }
-  }
-}
-```
-
-**Example Template:**
-
-```json
-{
-  "metadata": {
-    "id": "did:example:123",
-    "templateId": "did:template:consulting-v1",
-    "version": "1.0.0",
-    "createdAt": "2024-03-20T12:00:00Z",
-    "name": "Consulting Agreement Template",
-    "author": "Jane Doe",
-    "description": "Standard template for one-hour consulting services with USDC payment"
-  },
-  "variables": [
-    {
-      "id": "partyB",
-      "type": "string",
-      "name": "Party B",
-      "description": "Name of the party receiving consulting services",
-      "validation": {
-        "required": true,
-        "minLength": 1
-      }
-    },
-    {
-      "id": "amount",
-      "type": "number",
-      "name": "USDC Amount",
-      "description": "Amount of USDC to be paid for services",
-      "validation": {
-        "required": true,
-        "min": 1
-      }
-    },
-    {
-      "id": "partyBAddress",
-      "type": "address",
-      "name": "Party B Ethereum Address",
-      "description": "Ethereum address of Party B",
-      "validation": {
-        "required": true,
-        "pattern": "^0x[a-fA-F0-9]{40}$"
-      }
-    }
-  ],
-  "content": {
-    "type": "md",
-    "data": "# Agreement\n\nI, Jane Doe, agree to provide :variable{id='partyB'} with one hour of startup business advice.\n\nIn exchange, :variable{id='partyB'} agrees to transfer :variable{id='amount'} USDC to my Ethereum address: 0x123...abcd on the Ethereum mainnet.\n\n**Signature:** Jane Doe\n**Ethereum Address:** 0x123...abcd\n\n**Signature:** :variable{id='partyB'}\n**Ethereum Address:** :variable{id='partyBAddress'}"
-  },
-  "execution": {
-    "type": "dfsm",
-    "data": {
-      "states": [
-        "PENDING_SIGNATURE",
-        "SIGNED"
-      ],
-      "inputs": {
-        "partyBSignature": {
-          "id": "partyBSignature",
-          "type": "VerifiedCredentialEIP712",
-          "schema": "verified-credential-eip712.schema.json",
-          "displayName": "Party B Signature",
-          "description": "EIP712 signature from Party B accepting the agreement terms",
-          "value": {
-            "hasAcceptedTerms": true
-          },
-          "signer": "${partyBAddress}"
-        }
-      },
-      "transitions": [
-        {
-          "from": "PENDING_SIGNATURE",
-          "to": "SIGNED",
-          "conditions": [
-            {
-              "type": "isValid",
-              "inputs": ["partyBSignature"]
-            }
-          ]
-        }
-      ]
-    }
-  }
-}
-```
-
-### 6. Verifiable Credential Wrapper
-
-The entire agreement can be wrapped in a W3C Verifiable Credential to provide cryptographic proof of its authenticity and integrity. This wrapper adds several important properties:
-
-1. **Non-tamperability**: The entire agreement is cryptographically signed using EIP-712
-2. **Non-repudiation**: The issuer's signature proves they created and approved the agreement
-3. **Expiration**: The credential can have an expiration date
-4. **Context**: The credential provides rich metadata about the agreement's context
-
-**Example Usage:**
-
-```json
-{
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1",
-    "https://identity.foundation/EcdsaSecp256k1RecoverySignature2020/lds-ecdsa-secp256k1-recovery2020-0.0.jsonld"
-  ],
-  "id": "did:example:agreement-vc-1",
-  "type": ["VerifiableCredential", "AgreementCredential"],
-  "issuer": {
-    "id": "did:example:issuer-1",
-    "name": "Agreement Issuer"
-  },
-  "issuanceDate": "2024-03-20T12:00:00Z",
-  "expirationDate": "2025-03-20T12:00:00Z",
-  "credentialSubject": {
-    "id": "did:example:subject-1",
-    "agreement": {
-      // ... full agreement content ...
-    }
-  },
-  "proof": {
-    "type": "EthereumEip712Signature2021",
-    "created": "2024-03-20T12:00:00Z",
-    "proofPurpose": "contractAgreement",
-    "verificationMethod": "did:example:issuer-1#key-1",
-    "eip712": {
-      // ... EIP-712 domain and type definitions ...
-    },
-    "proofValue": "0x..."
-  }
-}
-```
-
-See [grant-agreement-vc-wrapped.json](./templates/grant-agreement-vc-wrapped.json) for a complete example of a wrapped agreement.
-See [verified-credential-eip712.schema.json](./schemas/verified-credential-eip712.schema.json) for the wrapper format.
-
-## Getting Started
-
-### 1. Templates
-
-The following agreement templates are available as reference implementations:
-
-#### Grant Agreement
-
-A standardized agreement for ecosystem development funding that includes:
-
-- Foundation and grant recipient details
-- Token allocation specifications
-- RFP reference and grant activities
-- Token distribution terms
-
-Example content formats:
-
-- [MDAST version](./templates/grant-agreement.json) - Structured format with rich semantic information
-- [Markdown version](./templates/grant-agreement.md.json) - Human-readable format with variable interpolation
-
-Full examples including execution environment definition:
-- [Markdown content + DFSM execution](./templates/grant-agreement.md.dfsm.json) ([State Machine Visualization](./templates/grant-agreement.md.dfsm.json.md))
-
-#### Creating Custom Templates
-
-Creating agreement templates is simple with AI assistance. Here's how to get started:
-
-1. **Prepare Your Agreement**
-   Start with your agreement in markdown format.
-
-2. **Provide Context**
-   Share these files with your AI assistant:
-   - [README](./README.md) - Protocol overview and examples
-   - [Template Schema](./schemas/template.schema.json) - JSON schema definition
-   - [MDAST Schema](./schemas/mdast.schema.json) - Content structure specification
-   - [Grant Agreement](./templates/grant-agreement.json) - Reference implementation
-
-3. **Generate Template**
-   Use this prompt format:
-   ```
-   Help me create an agreement template following the Agreements Protocol standard.
-
-   Agreement Type: Consulting Agreement
-   Purpose: One-hour consulting session with USDC payment
-   Variables: 
-   - Party B name and address
-   - Payment amount
-   - Signing date
-   Format: MDAST (preferred for structured content)
-
-   Here's my agreement:
-   <paste your markdown agreement>
-   ```
-
-### 2. Validate Your Templates
-
-Use our JSON schemas to validate your agreement templates:
-
-- [Template Schema](./schemas/template.schema.json)
-- [MDAST Schema](./schemas/mdast.schema.json)
+They are not the canonical schema entry points for new work. New work should target the canonical files under `schemas/core`, `schemas/profiles`, `schemas/compositions`, and the corresponding `templates/` subdirectories.
 
 ## Contributing
 
-We welcome contributions to the Agreements Protocol! Please see our [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to get involved.
+See [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -256,14 +256,14 @@ More detail:
 
 The canonical schema trees are now also modeled as npm workspace modules:
 
-- `@agreements-standard/core`
-- `@agreements-standard/profile-evm`
-- `@agreements-standard/profile-vc`
-- `@agreements-standard/profile-eip712`
-- `@agreements-standard/composition-evm-eip712`
-- `@agreements-standard/composition-vc-eip712`
-- `@agreements-standard/composition-evm-vc-eip712`
-- `@agreements-standard/fixtures`
+- `@cns/agreements-core`
+- `@cns/agreements-profile-evm`
+- `@cns/agreements-profile-vc`
+- `@cns/agreements-profile-eip712`
+- `@cns/agreements-composition-evm-eip712`
+- `@cns/agreements-composition-vc-eip712`
+- `@cns/agreements-composition-evm-vc-eip712`
+- `@cns/agreements-fixtures`
 
 This keeps the schema source-of-truth in the repo while giving implementations a package boundary they can depend on directly. The canonical schema files remain under `schemas/`, and the canonical example documents remain under `templates/`.
 
@@ -272,7 +272,7 @@ This keeps the schema source-of-truth in the repo while giving implementations a
 Versioning is split by concern:
 
 - documents declare `standard.coreVersion` and explicit profile versions
-- `@agreements-standard/core` tracks the core schema version
+- `@cns/agreements-core` tracks the core schema version
 - profile and composition packages track their own schema versions
 - implementations should declare the package version ranges they support and reject incompatible documents
 

--- a/improvement-proposals/IP-001.md
+++ b/improvement-proposals/IP-001.md
@@ -31,7 +31,7 @@ While the current version uses a deterministic finite state machine approach, **
 
 ### JSON Structure Enhancements
 
-The version of this protocol will extend the JSON structure with new sections:
+The next version of this standard will extend the JSON structure with new sections:
 
 ```json
 {
@@ -75,7 +75,7 @@ With the abstract state machine approach, agreements will be able to:
    - Algorithmic dispute resolution
    - Game-theoretic incentive structures
 
-The transition from a finite state machine (v1) to an abstract state machine (v2) represents a quantum leap in agreement protocol capabilities, moving from rigid, predetermined execution paths to a fully programmable, Turing-complete agreement definition language. 
+The transition from a finite state machine (v1) to an abstract state machine (v2) represents a quantum leap in agreement standard capabilities, moving from rigid, predetermined execution paths to a fully programmable, Turing-complete agreement definition language. 
 
 | Feature                              | DFSM | ASM |
 |--------------------------------------|------|-----|
@@ -85,7 +85,7 @@ The transition from a finite state machine (v1) to an abstract state machine (v2
 | **Computation Between Transitions**  | ❌   | ✅  |
 | **Complex Logic (Assertions, Conditions)** | ❌ | ✅ |
 
-This document describes how the protocol might evolve over time.
+This document describes how the standard might evolve over time.
 
 # V1 Example: DFSM-Based Grant Legal Agreement
 
@@ -129,7 +129,7 @@ Still event-driven and reliant on provable inputs (VCs, ZK proofs).
 
 ----
 
-Sample Grant Agreeement using DFSM (see https://github.com/ConsenSysMesh/agreements-protocol/blob/master/src/templates/grant-agreement-DFSM.json as input)
+Sample Grant Agreement using DFSM (see [templates/grant-agreement.md.dfsm.json](../templates/grant-agreement.md.dfsm.json) as input)
 
 ```mermaid
 stateDiagram-v2
@@ -144,4 +144,3 @@ stateDiagram-v2
     PAYMENT_PENDING --> COMPLETED: grantTransactionProof valid
     COMPLETED --> [*]
 ```
-

--- a/improvement-proposals/IP-002.md
+++ b/improvement-proposals/IP-002.md
@@ -8,7 +8,7 @@ This proposal recommends using Markdown and [MDAST (Markdown Abstract Syntax Tre
 
 ### Problem Statement
 
-Blocknote.js JSON is difficult to manipulate and transport between systems due to its proprietary structure, creating challenges when storing it inside an agreement protocol.
+Blocknote.js JSON is difficult to manipulate and transport between systems due to its proprietary structure, creating challenges when storing it inside an agreement standard document.
 
 ### Proposed Solution
 
@@ -34,7 +34,7 @@ Shift to Markdown and MDAST (Markdown Abstract Syntax Tree) to enable:
 | --- | --- | --- |
 | **Simplicity** | ✅ Simpler syntax, familiar to non-technical users | ⚠️ Slightly more complex |
 | **Custom Elements** | ❌ No native support for custom elements | ✅ First-class support for custom nodes |
-| **Validation** | ❌ Limited structural validation | ✅ Type-safe structure ensures protocol integrity |
+| **Validation** | ❌ Limited structural validation | ✅ Type-safe structure ensures standard integrity |
 | **Programmability** | ❌ Harder to manipulate programmatically | ✅ Easy programmatic updates |
 | **Type Safety** | ❌ Error-prone text processing | ✅ Typed structure prevents errors |
 | **Human Readability** | ✅ Directly readable and editable as text | ❌ Requires tooling to read/edit comfortably |
@@ -43,10 +43,10 @@ Shift to Markdown and MDAST (Markdown Abstract Syntax Tree) to enable:
 
 **Recommendation**: Use MDAST for agreements requiring variable substitution, address formatting, and structural validation. Plain Markdown may suffice for simple agreements without dynamic content.
 
-## Protocol Structure
+## Standard Structure
 
 ```tsx
-interface AgreementProtocol {
+interface AgreementDocument {
   version: string;
   variables: VariableDefinition[];
   content_mdast: MDAST;  // The MDAST root node - can be converted to/from Markdown
@@ -91,12 +91,12 @@ interface Address {
 
 ## Representation Examples
 
-Agreement content can be stored as MDAST in the protocol and converted to/from Markdown with directives:
+Agreement content can be stored as MDAST in the standard document and converted to/from Markdown with directives:
 
 > **Note**: support could also be added to go from MDAST to/from BlockNote.js JSON
 > 
 
-### Protocol JSON
+### Standard JSON
 
 ```json
 {
@@ -213,9 +213,9 @@ The directive approach balances readability, structural support, and ecosystem i
 
 ## Workflow
 
-### Reading Protocol
+### Reading the Document
 
-1. Parse Protocol JSON
+1. Parse Standard JSON
 2. Extract variable defaults
 3. Process MDAST to desired output
 4. Render with variable values and formatted addresses
@@ -223,7 +223,7 @@ The directive approach balances readability, structural support, and ecosystem i
 ### Updating Variables
 
 1. Capture user input
-2. Update protocol with `saveVariableValue`
+2. Update the agreement document with `saveVariableValue`
 3. Re-render with new values
 4. Persist changes when needed
 
@@ -236,20 +236,20 @@ The directive approach balances readability, structural support, and ecosystem i
 import React, { useState } from 'react';
 import { AgreementRenderer, saveVariableValue } from './agreement-utils';
 
-export default function AgreementEditor({ initialProtocol }) {
-  const [protocol, setProtocol] = useState(initialProtocol);
+export default function AgreementEditor({ initialAgreement }) {
+  const [agreement, setAgreement] = useState(initialAgreement);
 
   // Handle variable changes
   const handleVariableChange = (name, value) => {
-    // Update protocol with new variable value
-    const updatedProtocol = saveVariableValue(protocol, name, value);
-    setProtocol(updatedProtocol);
+    // Update the agreement document with the new variable value
+    const updatedAgreement = saveVariableValue(agreement, name, value);
+    setAgreement(updatedAgreement);
   };
 
   // Handle agreement submission
   const handleSubmit = () => {
     // Validate all variables before submission
-    const isValid = protocol.variables.every(variable => {
+    const isValid = agreement.variables.every(variable => {
       if (variable.validation?.required && !variable.default) {
         return false;
       }
@@ -261,10 +261,10 @@ export default function AgreementEditor({ initialProtocol }) {
     });
 
     if (isValid) {
-      // Submit protocol to API/blockchain/storage
-      console.log('Submitting valid protocol', protocol);
+      // Submit the agreement document to API/blockchain/storage
+      console.log('Submitting valid agreement document', agreement);
     } else {
-      console.error('Invalid protocol - validation failed');
+      console.error('Invalid agreement document - validation failed');
     }
   };
 
@@ -274,7 +274,7 @@ export default function AgreementEditor({ initialProtocol }) {
 
       {/* Render the agreement with editable variables */}
       <AgreementRenderer
-        protocol={protocol}
+        agreement={agreement}
         editable={true}
         onVariableChange={handleVariableChange}
       />
@@ -349,21 +349,21 @@ export function variableValuesPlugin(variables = {}) {
   };
 }
 
-// Function to save a new variable value back to the protocol object
-export function saveVariableValue(protocol, variableName, newValue) {
+// Function to save a new variable value back to the agreement document
+export function saveVariableValue(agreementDocument, variableName, newValue) {
   // Create a deep copy to avoid mutating the original
-  const updatedProtocol = JSON.parse(JSON.stringify(protocol));
+  const updatedAgreement = JSON.parse(JSON.stringify(agreementDocument));
 
   // Update the default value in the variables array
-  const variableIndex = updatedProtocol.variables.findIndex(
+  const variableIndex = updatedAgreement.variables.findIndex(
     (v) => v.name === variableName
   );
 
   if (variableIndex !== -1) {
-    updatedProtocol.variables[variableIndex].default = newValue;
+    updatedAgreement.variables[variableIndex].default = newValue;
   }
 
-  return updatedProtocol;
+  return updatedAgreement;
 }
 ```
 
@@ -418,9 +418,9 @@ const AddressComponent = ({ value, display = "truncated" }) => {
 This example shows how to implement a complete agreement renderer:
 
 ```tsx
-function AgreementRenderer({ protocol, editable = false, onVariableChange }) {
+function AgreementRenderer({ agreement, editable = false, onVariableChange }) {
   // Extract variables into a flat map
-  const variableValues = protocol.variables.reduce((acc, v) => {
+  const variableValues = agreement.variables.reduce((acc, v) => {
     acc[v.name] = v.default || '';
     return acc;
   }, {});
@@ -465,9 +465,9 @@ function AgreementRenderer({ protocol, editable = false, onVariableChange }) {
     });
 
   // Process content - handles both string markdown or MDAST
-  const content = typeof protocol.content === 'string'
-    ? processor.processSync(protocol.content).result
-    : processor.runSync(protocol.content);
+  const content = typeof agreement.content === 'string'
+    ? processor.processSync(agreement.content).result
+    : processor.runSync(agreement.content);
 
   return <div className="agreement-document">{content}</div>;
 }

--- a/improvement-proposals/IP-004.md
+++ b/improvement-proposals/IP-004.md
@@ -2,21 +2,21 @@
 
 ## Executive Summary
 
-This improvement proposal (IP-004) introduces a standardized approach to variable management, content representation, and metadata handling in the agreements protocol. It defines:
+This improvement proposal (IP-004) introduces a standardized approach to variable management, content representation, and metadata handling in the agreements standard. It defines:
 
 1. A flat variable structure with rich descriptors and validation rules
 2. Support for multiple content types with initial focus on MDAST and Markdown
 3. Enhanced metadata descriptors for agreement templates
 4. JSON schema definitions for validation and generation
 
-These improvements aim to enhance interoperability between protocol logic and client applications while providing a robust foundation for template validation and AI-assisted generation.
+These improvements aim to enhance interoperability between the standard model and client applications while providing a robust foundation for template validation and AI-assisted generation.
 
 ## Overview
 
 ### Problem Statement
 
-1. **Protocol-Client Interface Limitations**
-   * Lack of clear separation between protocol logic and client interfaces
+1. **Standard-Client Interface Limitations**
+   * Lack of clear separation between the standard model and client interfaces
    * Missing variable decorators for improved cross-stack visibility
    * Incomplete validation rule specifications
    * Excessive complexity from nested variable dependencies
@@ -38,7 +38,7 @@ These improvements aim to enhance interoperability between protocol logic and cl
 1. **Standardized Variable System**
    * Flat variable structure with comprehensive descriptors
    * Robust validation framework
-   * Clean separation of protocol and interface layers
+   * Clean separation of standard and interface layers
 
 2. **Flexible Content Architecture**
    * Core support for MDAST and Markdown formats
@@ -168,7 +168,7 @@ In markdown content, variables can be referenced using directives:
 
 ## 2. Content Types
 
-The protocol supports multiple content representation formats through a flexible type system. This allows templates to be authored and processed in different formats while maintaining consistent variable handling and validation.
+The standard supports multiple content representation formats through a flexible type system. This allows templates to be authored and processed in different formats while maintaining consistent variable handling and validation.
 
 ### Schema Definition
 
@@ -306,7 +306,7 @@ Agreement templates include rich metadata to provide context and identification:
 
 ## 4. JSON Schemas
 
-The protocol defines JSON schemas to enable validation and tooling support. These schemas are located in the `./schema/` directory:
+The standard defines JSON schemas to enable validation and tooling support. These schemas are located in the `./schema/` directory:
 
 ### Template Schema (`template.schema.json`)
 
@@ -346,7 +346,7 @@ Defines the structure for MDAST content, including:
 - Node type definitions
 - Child node relationships
 - Variable reference validation
-- Custom node types for the protocol
+- Custom node types for the standard
 
 The schemas serve multiple purposes:
 1. Runtime validation of templates and content
@@ -390,4 +390,4 @@ This reference syntax provides a unified way to access variables and their prope
 
 ### Future Improvements
 
-As we continue developing the protocol, this IP should serve as a helpful reference point for adding new features such as state-machine and proofs. The flat variable structure, content type system, and schema definitions provide a solid foundation that we can build upon.
+As we continue developing the standard, this IP should serve as a helpful reference point for adding new features such as state-machine and proofs. The flat variable structure, content type system, and schema definitions provide a solid foundation that we can build upon.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "agreements-standard-workspace",
+  "private": true,
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "workspaces": [
+    "schemas/core",
+    "schemas/profiles/evm",
+    "schemas/profiles/vc",
+    "schemas/profiles/eip712",
+    "schemas/compositions/evm-eip712",
+    "schemas/compositions/vc-eip712",
+    "schemas/compositions/evm-vc-eip712",
+    "templates"
+  ],
+  "scripts": {
+    "verify:modules": "node ./scripts/verify-modules.mjs",
+    "verify": "npm run verify:modules"
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -8,13 +8,13 @@ Canonical schemas are organized into three layers:
 
 These canonical schema directories are also npm workspace packages:
 
-- `core/` -> `@cns/agreements-core`
-- `profiles/evm/` -> `@cns/agreements-profile-evm`
-- `profiles/vc/` -> `@cns/agreements-profile-vc`
-- `profiles/eip712/` -> `@cns/agreements-profile-eip712`
-- `compositions/evm-eip712/` -> `@cns/agreements-composition-evm-eip712`
-- `compositions/vc-eip712/` -> `@cns/agreements-composition-vc-eip712`
-- `compositions/evm-vc-eip712/` -> `@cns/agreements-composition-evm-vc-eip712`
+- `core/` -> `@cns-labs/agreements-core`
+- `profiles/evm/` -> `@cns-labs/agreements-profile-evm`
+- `profiles/vc/` -> `@cns-labs/agreements-profile-vc`
+- `profiles/eip712/` -> `@cns-labs/agreements-profile-eip712`
+- `compositions/evm-eip712/` -> `@cns-labs/agreements-composition-evm-eip712`
+- `compositions/vc-eip712/` -> `@cns-labs/agreements-composition-vc-eip712`
+- `compositions/evm-vc-eip712/` -> `@cns-labs/agreements-composition-evm-vc-eip712`
 
 Use these as the authoritative schema entry points for new work:
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -8,13 +8,13 @@ Canonical schemas are organized into three layers:
 
 These canonical schema directories are also npm workspace packages:
 
-- `core/` -> `@agreements-standard/core`
-- `profiles/evm/` -> `@agreements-standard/profile-evm`
-- `profiles/vc/` -> `@agreements-standard/profile-vc`
-- `profiles/eip712/` -> `@agreements-standard/profile-eip712`
-- `compositions/evm-eip712/` -> `@agreements-standard/composition-evm-eip712`
-- `compositions/vc-eip712/` -> `@agreements-standard/composition-vc-eip712`
-- `compositions/evm-vc-eip712/` -> `@agreements-standard/composition-evm-vc-eip712`
+- `core/` -> `@cns/agreements-core`
+- `profiles/evm/` -> `@cns/agreements-profile-evm`
+- `profiles/vc/` -> `@cns/agreements-profile-vc`
+- `profiles/eip712/` -> `@cns/agreements-profile-eip712`
+- `compositions/evm-eip712/` -> `@cns/agreements-composition-evm-eip712`
+- `compositions/vc-eip712/` -> `@cns/agreements-composition-vc-eip712`
+- `compositions/evm-vc-eip712/` -> `@cns/agreements-composition-evm-vc-eip712`
 
 Use these as the authoritative schema entry points for new work:
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,26 @@
+# Schemas
+
+Canonical schemas are organized into three layers:
+
+- `core/` for the base agreement document model
+- `profiles/` for orthogonal concerns such as `evm`, `vc`, and `eip712`
+- `compositions/` for explicit combinations of profiles
+
+Use these as the authoritative schema entry points for new work:
+
+- [core/agreement.schema.json](./core/agreement.schema.json)
+- [profiles/evm/agreement.schema.json](./profiles/evm/agreement.schema.json)
+- [profiles/vc/agreement-envelope.schema.json](./profiles/vc/agreement-envelope.schema.json)
+- [profiles/eip712/agreement.schema.json](./profiles/eip712/agreement.schema.json)
+- [compositions/evm-eip712/agreement.schema.json](./compositions/evm-eip712/agreement.schema.json)
+- [compositions/vc-eip712/agreement-envelope.schema.json](./compositions/vc-eip712/agreement-envelope.schema.json)
+- [compositions/evm-vc-eip712/agreement-envelope.schema.json](./compositions/evm-vc-eip712/agreement-envelope.schema.json)
+
+Legacy pre-IP-005 schema files are still present at the root of this directory:
+
+- `template.schema.json`
+- `execution-dfsm.schema.json`
+- `mdast.schema.json`
+- `verified-credential-eip712.schema.json`
+
+Those files are retained for reference and legacy compatibility only.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -6,6 +6,16 @@ Canonical schemas are organized into three layers:
 - `profiles/` for orthogonal concerns such as `evm`, `vc`, and `eip712`
 - `compositions/` for explicit combinations of profiles
 
+These canonical schema directories are also npm workspace packages:
+
+- `core/` -> `@agreements-standard/core`
+- `profiles/evm/` -> `@agreements-standard/profile-evm`
+- `profiles/vc/` -> `@agreements-standard/profile-vc`
+- `profiles/eip712/` -> `@agreements-standard/profile-eip712`
+- `compositions/evm-eip712/` -> `@agreements-standard/composition-evm-eip712`
+- `compositions/vc-eip712/` -> `@agreements-standard/composition-vc-eip712`
+- `compositions/evm-vc-eip712/` -> `@agreements-standard/composition-evm-vc-eip712`
+
 Use these as the authoritative schema entry points for new work:
 
 - [core/agreement.schema.json](./core/agreement.schema.json)

--- a/schemas/compositions/evm-eip712/package.json
+++ b/schemas/compositions/evm-eip712/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@agreements-standard/composition-evm-eip712",
+  "name": "@cns/agreements-composition-evm-eip712",
   "version": "1.0.0-draft.0",
   "description": "EVM + EIP-712 composition schemas for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@agreements-standard/core": "1.1.0-draft.0",
-    "@agreements-standard/profile-evm": "1.0.0-draft.0",
-    "@agreements-standard/profile-eip712": "1.0.0-draft.0"
+    "@cns/agreements-core": "1.1.0-draft.0",
+    "@cns/agreements-profile-evm": "1.0.0-draft.0",
+    "@cns/agreements-profile-eip712": "1.0.0-draft.0"
   },
   "files": [
     "*.schema.json",

--- a/schemas/compositions/evm-eip712/package.json
+++ b/schemas/compositions/evm-eip712/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@agreements-standard/composition-evm-eip712",
+  "version": "1.0.0-draft.0",
+  "description": "EVM + EIP-712 composition schemas for the Agreements Standard.",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@agreements-standard/core": "1.1.0-draft.0",
+    "@agreements-standard/profile-evm": "1.0.0-draft.0",
+    "@agreements-standard/profile-eip712": "1.0.0-draft.0"
+  },
+  "files": [
+    "*.schema.json",
+    "execution/*.schema.json",
+    "package.json"
+  ],
+  "exports": {
+    ".": "./agreement.schema.json",
+    "./agreement.schema.json": "./agreement.schema.json",
+    "./execution/input-eip712-attestation.schema.json": "./execution/input-eip712-attestation.schema.json",
+    "./package.json": "./package.json"
+  }
+}

--- a/schemas/compositions/evm-eip712/package.json
+++ b/schemas/compositions/evm-eip712/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@cns/agreements-composition-evm-eip712",
+  "name": "@cns-labs/agreements-composition-evm-eip712",
   "version": "1.0.0-draft.0",
   "description": "EVM + EIP-712 composition schemas for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cns/agreements-core": "1.1.0-draft.0",
-    "@cns/agreements-profile-evm": "1.0.0-draft.0",
-    "@cns/agreements-profile-eip712": "1.0.0-draft.0"
+    "@cns-labs/agreements-core": "1.1.0-draft.0",
+    "@cns-labs/agreements-profile-evm": "1.0.0-draft.0",
+    "@cns-labs/agreements-profile-eip712": "1.0.0-draft.0"
   },
   "files": [
     "*.schema.json",

--- a/schemas/compositions/evm-vc-eip712/package.json
+++ b/schemas/compositions/evm-vc-eip712/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@cns/agreements-composition-evm-vc-eip712",
+  "name": "@cns-labs/agreements-composition-evm-vc-eip712",
   "version": "1.0.0-draft.0",
   "description": "EVM + VC + EIP-712 composition schemas for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cns/agreements-composition-evm-eip712": "1.0.0-draft.0",
-    "@cns/agreements-composition-vc-eip712": "1.0.0-draft.0"
+    "@cns-labs/agreements-composition-evm-eip712": "1.0.0-draft.0",
+    "@cns-labs/agreements-composition-vc-eip712": "1.0.0-draft.0"
   },
   "files": [
     "*.schema.json",

--- a/schemas/compositions/evm-vc-eip712/package.json
+++ b/schemas/compositions/evm-vc-eip712/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@agreements-standard/composition-evm-vc-eip712",
+  "version": "1.0.0-draft.0",
+  "description": "EVM + VC + EIP-712 composition schemas for the Agreements Standard.",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@agreements-standard/composition-evm-eip712": "1.0.0-draft.0",
+    "@agreements-standard/composition-vc-eip712": "1.0.0-draft.0"
+  },
+  "files": [
+    "*.schema.json",
+    "package.json"
+  ],
+  "exports": {
+    ".": "./agreement-envelope.schema.json",
+    "./agreement-envelope.schema.json": "./agreement-envelope.schema.json",
+    "./package.json": "./package.json"
+  }
+}

--- a/schemas/compositions/evm-vc-eip712/package.json
+++ b/schemas/compositions/evm-vc-eip712/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@agreements-standard/composition-evm-vc-eip712",
+  "name": "@cns/agreements-composition-evm-vc-eip712",
   "version": "1.0.0-draft.0",
   "description": "EVM + VC + EIP-712 composition schemas for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@agreements-standard/composition-evm-eip712": "1.0.0-draft.0",
-    "@agreements-standard/composition-vc-eip712": "1.0.0-draft.0"
+    "@cns/agreements-composition-evm-eip712": "1.0.0-draft.0",
+    "@cns/agreements-composition-vc-eip712": "1.0.0-draft.0"
   },
   "files": [
     "*.schema.json",

--- a/schemas/compositions/vc-eip712/package.json
+++ b/schemas/compositions/vc-eip712/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@agreements-standard/composition-vc-eip712",
+  "version": "1.0.0-draft.0",
+  "description": "VC + EIP-712 composition schemas for the Agreements Standard.",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@agreements-standard/core": "1.1.0-draft.0",
+    "@agreements-standard/profile-vc": "1.0.0-draft.0",
+    "@agreements-standard/profile-eip712": "1.0.0-draft.0"
+  },
+  "files": [
+    "*.schema.json",
+    "package.json"
+  ],
+  "exports": {
+    ".": "./agreement-envelope.schema.json",
+    "./agreement-envelope.schema.json": "./agreement-envelope.schema.json",
+    "./package.json": "./package.json"
+  }
+}

--- a/schemas/compositions/vc-eip712/package.json
+++ b/schemas/compositions/vc-eip712/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@agreements-standard/composition-vc-eip712",
+  "name": "@cns/agreements-composition-vc-eip712",
   "version": "1.0.0-draft.0",
   "description": "VC + EIP-712 composition schemas for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@agreements-standard/core": "1.1.0-draft.0",
-    "@agreements-standard/profile-vc": "1.0.0-draft.0",
-    "@agreements-standard/profile-eip712": "1.0.0-draft.0"
+    "@cns/agreements-core": "1.1.0-draft.0",
+    "@cns/agreements-profile-vc": "1.0.0-draft.0",
+    "@cns/agreements-profile-eip712": "1.0.0-draft.0"
   },
   "files": [
     "*.schema.json",

--- a/schemas/compositions/vc-eip712/package.json
+++ b/schemas/compositions/vc-eip712/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@cns/agreements-composition-vc-eip712",
+  "name": "@cns-labs/agreements-composition-vc-eip712",
   "version": "1.0.0-draft.0",
   "description": "VC + EIP-712 composition schemas for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cns/agreements-core": "1.1.0-draft.0",
-    "@cns/agreements-profile-vc": "1.0.0-draft.0",
-    "@cns/agreements-profile-eip712": "1.0.0-draft.0"
+    "@cns-labs/agreements-core": "1.1.0-draft.0",
+    "@cns-labs/agreements-profile-vc": "1.0.0-draft.0",
+    "@cns-labs/agreements-profile-eip712": "1.0.0-draft.0"
   },
   "files": [
     "*.schema.json",

--- a/schemas/core/package.json
+++ b/schemas/core/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@agreements-standard/core",
+  "version": "1.1.0-draft.0",
+  "description": "Chain-neutral core schemas for the Agreements Standard.",
+  "license": "Apache-2.0",
+  "files": [
+    "*.schema.json",
+    "execution/*.schema.json",
+    "package.json"
+  ],
+  "exports": {
+    ".": "./agreement.schema.json",
+    "./agreement.schema.json": "./agreement.schema.json",
+    "./metadata.schema.json": "./metadata.schema.json",
+    "./variables.schema.json": "./variables.schema.json",
+    "./content.schema.json": "./content.schema.json",
+    "./mdast.schema.json": "./mdast.schema.json",
+    "./execution/dfsm.schema.json": "./execution/dfsm.schema.json",
+    "./execution/input.schema.json": "./execution/input.schema.json",
+    "./package.json": "./package.json"
+  }
+}

--- a/schemas/core/package.json
+++ b/schemas/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cns/agreements-core",
+  "name": "@cns-labs/agreements-core",
   "version": "1.1.0-draft.0",
   "description": "Chain-neutral core schemas for the Agreements Standard.",
   "license": "Apache-2.0",

--- a/schemas/core/package.json
+++ b/schemas/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agreements-standard/core",
+  "name": "@cns/agreements-core",
   "version": "1.1.0-draft.0",
   "description": "Chain-neutral core schemas for the Agreements Standard.",
   "license": "Apache-2.0",

--- a/schemas/profiles/eip712/package.json
+++ b/schemas/profiles/eip712/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@cns/agreements-profile-eip712",
+  "name": "@cns-labs/agreements-profile-eip712",
   "version": "1.0.0-draft.0",
   "description": "EIP-712 profile schemas for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cns/agreements-core": "1.1.0-draft.0"
+    "@cns-labs/agreements-core": "1.1.0-draft.0"
   },
   "files": [
     "*.schema.json",

--- a/schemas/profiles/eip712/package.json
+++ b/schemas/profiles/eip712/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@agreements-standard/profile-eip712",
+  "name": "@cns/agreements-profile-eip712",
   "version": "1.0.0-draft.0",
   "description": "EIP-712 profile schemas for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@agreements-standard/core": "1.1.0-draft.0"
+    "@cns/agreements-core": "1.1.0-draft.0"
   },
   "files": [
     "*.schema.json",

--- a/schemas/profiles/eip712/package.json
+++ b/schemas/profiles/eip712/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@agreements-standard/profile-eip712",
+  "version": "1.0.0-draft.0",
+  "description": "EIP-712 profile schemas for the Agreements Standard.",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@agreements-standard/core": "1.1.0-draft.0"
+  },
+  "files": [
+    "*.schema.json",
+    "execution/*.schema.json",
+    "proofs/*.schema.json",
+    "package.json"
+  ],
+  "exports": {
+    ".": "./agreement.schema.json",
+    "./agreement.schema.json": "./agreement.schema.json",
+    "./execution/input-typed-data-signature.schema.json": "./execution/input-typed-data-signature.schema.json",
+    "./proofs/typed-data-proof.schema.json": "./proofs/typed-data-proof.schema.json",
+    "./package.json": "./package.json"
+  }
+}

--- a/schemas/profiles/evm/package.json
+++ b/schemas/profiles/evm/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@agreements-standard/profile-evm",
+  "version": "1.0.0-draft.0",
+  "description": "EVM profile schemas for the Agreements Standard.",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@agreements-standard/core": "1.1.0-draft.0"
+  },
+  "files": [
+    "agreement.schema.json",
+    "execution/*.schema.json",
+    "variables/*.schema.json",
+    "package.json"
+  ],
+  "exports": {
+    ".": "./agreement.schema.json",
+    "./agreement.schema.json": "./agreement.schema.json",
+    "./execution/input-transaction-receipt.schema.json": "./execution/input-transaction-receipt.schema.json",
+    "./variables/evm-address.semantic.schema.json": "./variables/evm-address.semantic.schema.json",
+    "./package.json": "./package.json"
+  }
+}

--- a/schemas/profiles/evm/package.json
+++ b/schemas/profiles/evm/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@agreements-standard/profile-evm",
+  "name": "@cns/agreements-profile-evm",
   "version": "1.0.0-draft.0",
   "description": "EVM profile schemas for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@agreements-standard/core": "1.1.0-draft.0"
+    "@cns/agreements-core": "1.1.0-draft.0"
   },
   "files": [
     "agreement.schema.json",

--- a/schemas/profiles/evm/package.json
+++ b/schemas/profiles/evm/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@cns/agreements-profile-evm",
+  "name": "@cns-labs/agreements-profile-evm",
   "version": "1.0.0-draft.0",
   "description": "EVM profile schemas for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cns/agreements-core": "1.1.0-draft.0"
+    "@cns-labs/agreements-core": "1.1.0-draft.0"
   },
   "files": [
     "agreement.schema.json",

--- a/schemas/profiles/vc/package.json
+++ b/schemas/profiles/vc/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@cns/agreements-profile-vc",
+  "name": "@cns-labs/agreements-profile-vc",
   "version": "1.0.0-draft.0",
   "description": "VC profile schemas for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cns/agreements-core": "1.1.0-draft.0"
+    "@cns-labs/agreements-core": "1.1.0-draft.0"
   },
   "files": [
     "*.schema.json",

--- a/schemas/profiles/vc/package.json
+++ b/schemas/profiles/vc/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@agreements-standard/profile-vc",
+  "version": "1.0.0-draft.0",
+  "description": "VC profile schemas for the Agreements Standard.",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@agreements-standard/core": "1.1.0-draft.0"
+  },
+  "files": [
+    "*.schema.json",
+    "execution/*.schema.json",
+    "package.json"
+  ],
+  "exports": {
+    ".": "./agreement-envelope.schema.json",
+    "./agreement-envelope.schema.json": "./agreement-envelope.schema.json",
+    "./execution/input-verifiable-credential.schema.json": "./execution/input-verifiable-credential.schema.json",
+    "./package.json": "./package.json"
+  }
+}

--- a/schemas/profiles/vc/package.json
+++ b/schemas/profiles/vc/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@agreements-standard/profile-vc",
+  "name": "@cns/agreements-profile-vc",
   "version": "1.0.0-draft.0",
   "description": "VC profile schemas for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@agreements-standard/core": "1.1.0-draft.0"
+    "@cns/agreements-core": "1.1.0-draft.0"
   },
   "files": [
     "*.schema.json",

--- a/scripts/verify-modules.mjs
+++ b/scripts/verify-modules.mjs
@@ -7,7 +7,7 @@ const rootDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const specs = [
   {
     dir: "schemas/core",
-    name: "@agreements-standard/core",
+    name: "@cns/agreements-core",
     version: "1.1.0-draft.0",
     primary: "agreement.schema.json",
     mode: "schema",
@@ -15,77 +15,77 @@ const specs = [
   },
   {
     dir: "schemas/profiles/evm",
-    name: "@agreements-standard/profile-evm",
+    name: "@cns/agreements-profile-evm",
     version: "1.0.0-draft.0",
     primary: "agreement.schema.json",
     mode: "schema",
-    deps: ["@agreements-standard/core"]
+    deps: ["@cns/agreements-core"]
   },
   {
     dir: "schemas/profiles/vc",
-    name: "@agreements-standard/profile-vc",
+    name: "@cns/agreements-profile-vc",
     version: "1.0.0-draft.0",
     primary: "agreement-envelope.schema.json",
     mode: "schema",
-    deps: ["@agreements-standard/core"]
+    deps: ["@cns/agreements-core"]
   },
   {
     dir: "schemas/profiles/eip712",
-    name: "@agreements-standard/profile-eip712",
+    name: "@cns/agreements-profile-eip712",
     version: "1.0.0-draft.0",
     primary: "agreement.schema.json",
     mode: "schema",
-    deps: ["@agreements-standard/core"]
+    deps: ["@cns/agreements-core"]
   },
   {
     dir: "schemas/compositions/evm-eip712",
-    name: "@agreements-standard/composition-evm-eip712",
+    name: "@cns/agreements-composition-evm-eip712",
     version: "1.0.0-draft.0",
     primary: "agreement.schema.json",
     mode: "schema",
     deps: [
-      "@agreements-standard/core",
-      "@agreements-standard/profile-evm",
-      "@agreements-standard/profile-eip712"
+      "@cns/agreements-core",
+      "@cns/agreements-profile-evm",
+      "@cns/agreements-profile-eip712"
     ]
   },
   {
     dir: "schemas/compositions/vc-eip712",
-    name: "@agreements-standard/composition-vc-eip712",
+    name: "@cns/agreements-composition-vc-eip712",
     version: "1.0.0-draft.0",
     primary: "agreement-envelope.schema.json",
     mode: "schema",
     deps: [
-      "@agreements-standard/core",
-      "@agreements-standard/profile-vc",
-      "@agreements-standard/profile-eip712"
+      "@cns/agreements-core",
+      "@cns/agreements-profile-vc",
+      "@cns/agreements-profile-eip712"
     ]
   },
   {
     dir: "schemas/compositions/evm-vc-eip712",
-    name: "@agreements-standard/composition-evm-vc-eip712",
+    name: "@cns/agreements-composition-evm-vc-eip712",
     version: "1.0.0-draft.0",
     primary: "agreement-envelope.schema.json",
     mode: "schema",
     deps: [
-      "@agreements-standard/composition-evm-eip712",
-      "@agreements-standard/composition-vc-eip712"
+      "@cns/agreements-composition-evm-eip712",
+      "@cns/agreements-composition-vc-eip712"
     ]
   },
   {
     dir: "templates",
-    name: "@agreements-standard/fixtures",
+    name: "@cns/agreements-fixtures",
     version: "1.0.0-draft.0",
     primary: "fixtures.manifest.json",
     mode: "fixtures",
     deps: [
-      "@agreements-standard/core",
-      "@agreements-standard/profile-evm",
-      "@agreements-standard/profile-vc",
-      "@agreements-standard/profile-eip712",
-      "@agreements-standard/composition-evm-eip712",
-      "@agreements-standard/composition-vc-eip712",
-      "@agreements-standard/composition-evm-vc-eip712"
+      "@cns/agreements-core",
+      "@cns/agreements-profile-evm",
+      "@cns/agreements-profile-vc",
+      "@cns/agreements-profile-eip712",
+      "@cns/agreements-composition-evm-eip712",
+      "@cns/agreements-composition-vc-eip712",
+      "@cns/agreements-composition-evm-vc-eip712"
     ]
   }
 ];
@@ -196,7 +196,7 @@ for (const spec of specs) {
 
 const fixturesManifest = readJson("templates/fixtures.manifest.json");
 const fixturePaths = fixturesManifest.fixtures.map((fixture) => fixture.path.replace(/^\.\//, "")).sort();
-const expectedFixturePaths = listCanonicalFiles(specs.find((spec) => spec.name === "@agreements-standard/fixtures")).sort();
+const expectedFixturePaths = listCanonicalFiles(specs.find((spec) => spec.name === "@cns/agreements-fixtures")).sort();
 assert(
   JSON.stringify(fixturePaths) === JSON.stringify(expectedFixturePaths),
   "templates/fixtures.manifest.json does not match the canonical fixtures package exports"

--- a/scripts/verify-modules.mjs
+++ b/scripts/verify-modules.mjs
@@ -1,0 +1,213 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+const specs = [
+  {
+    dir: "schemas/core",
+    name: "@agreements-standard/core",
+    version: "1.1.0-draft.0",
+    primary: "agreement.schema.json",
+    mode: "schema",
+    deps: []
+  },
+  {
+    dir: "schemas/profiles/evm",
+    name: "@agreements-standard/profile-evm",
+    version: "1.0.0-draft.0",
+    primary: "agreement.schema.json",
+    mode: "schema",
+    deps: ["@agreements-standard/core"]
+  },
+  {
+    dir: "schemas/profiles/vc",
+    name: "@agreements-standard/profile-vc",
+    version: "1.0.0-draft.0",
+    primary: "agreement-envelope.schema.json",
+    mode: "schema",
+    deps: ["@agreements-standard/core"]
+  },
+  {
+    dir: "schemas/profiles/eip712",
+    name: "@agreements-standard/profile-eip712",
+    version: "1.0.0-draft.0",
+    primary: "agreement.schema.json",
+    mode: "schema",
+    deps: ["@agreements-standard/core"]
+  },
+  {
+    dir: "schemas/compositions/evm-eip712",
+    name: "@agreements-standard/composition-evm-eip712",
+    version: "1.0.0-draft.0",
+    primary: "agreement.schema.json",
+    mode: "schema",
+    deps: [
+      "@agreements-standard/core",
+      "@agreements-standard/profile-evm",
+      "@agreements-standard/profile-eip712"
+    ]
+  },
+  {
+    dir: "schemas/compositions/vc-eip712",
+    name: "@agreements-standard/composition-vc-eip712",
+    version: "1.0.0-draft.0",
+    primary: "agreement-envelope.schema.json",
+    mode: "schema",
+    deps: [
+      "@agreements-standard/core",
+      "@agreements-standard/profile-vc",
+      "@agreements-standard/profile-eip712"
+    ]
+  },
+  {
+    dir: "schemas/compositions/evm-vc-eip712",
+    name: "@agreements-standard/composition-evm-vc-eip712",
+    version: "1.0.0-draft.0",
+    primary: "agreement-envelope.schema.json",
+    mode: "schema",
+    deps: [
+      "@agreements-standard/composition-evm-eip712",
+      "@agreements-standard/composition-vc-eip712"
+    ]
+  },
+  {
+    dir: "templates",
+    name: "@agreements-standard/fixtures",
+    version: "1.0.0-draft.0",
+    primary: "fixtures.manifest.json",
+    mode: "fixtures",
+    deps: [
+      "@agreements-standard/core",
+      "@agreements-standard/profile-evm",
+      "@agreements-standard/profile-vc",
+      "@agreements-standard/profile-eip712",
+      "@agreements-standard/composition-evm-eip712",
+      "@agreements-standard/composition-vc-eip712",
+      "@agreements-standard/composition-evm-vc-eip712"
+    ]
+  }
+];
+
+const versionByName = Object.fromEntries(specs.map((spec) => [spec.name, spec.version]));
+
+const errors = [];
+let checkedFiles = 0;
+
+function readJson(relativePath) {
+  const absolutePath = path.join(rootDir, relativePath);
+  return JSON.parse(fs.readFileSync(absolutePath, "utf8"));
+}
+
+function exists(relativePath) {
+  return fs.existsSync(path.join(rootDir, relativePath));
+}
+
+function toPosix(relativePath) {
+  return relativePath.split(path.sep).join("/");
+}
+
+function walk(dirPath, files = []) {
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      walk(entryPath, files);
+      continue;
+    }
+    files.push(entryPath);
+  }
+  return files;
+}
+
+function listCanonicalFiles(spec) {
+  const absoluteDir = path.join(rootDir, spec.dir);
+  if (spec.mode === "schema") {
+    return walk(absoluteDir)
+      .filter((filePath) => filePath.endsWith(".schema.json"))
+      .map((filePath) => toPosix(path.relative(absoluteDir, filePath)))
+      .sort();
+  }
+
+  return ["core", "profiles", "compositions"]
+    .flatMap((subdir) => {
+      const absoluteSubdir = path.join(absoluteDir, subdir);
+      return walk(absoluteSubdir)
+        .filter((filePath) => filePath.endsWith(".json"))
+        .map((filePath) => toPosix(path.relative(absoluteDir, filePath)));
+    })
+    .sort();
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    errors.push(message);
+  }
+}
+
+const rootPackage = readJson("package.json");
+const expectedWorkspaces = specs.map((spec) => spec.dir).sort();
+const actualWorkspaces = [...(rootPackage.workspaces || [])].sort();
+assert(
+  JSON.stringify(actualWorkspaces) === JSON.stringify(expectedWorkspaces),
+  `Root workspaces do not match expected module directories.\nExpected: ${expectedWorkspaces.join(", ")}\nActual: ${actualWorkspaces.join(", ")}`
+);
+
+for (const spec of specs) {
+  const packageJsonPath = `${spec.dir}/package.json`;
+  assert(exists(packageJsonPath), `Missing package manifest: ${packageJsonPath}`);
+  if (!exists(packageJsonPath)) {
+    continue;
+  }
+
+  const pkg = readJson(packageJsonPath);
+  assert(pkg.name === spec.name, `Package ${packageJsonPath} has name ${pkg.name}; expected ${spec.name}`);
+  assert(pkg.version === spec.version, `Package ${pkg.name} has version ${pkg.version}; expected ${spec.version}`);
+  assert(typeof pkg.exports === "object" && pkg.exports !== null, `Package ${pkg.name} must define exports`);
+  assert(pkg.exports["."] === `./${spec.primary}`, `Package ${pkg.name} must map "." to "./${spec.primary}"`);
+  assert(pkg.exports[`./${spec.primary}`] === `./${spec.primary}`, `Package ${pkg.name} must export "./${spec.primary}"`);
+  assert(pkg.exports["./package.json"] === "./package.json", `Package ${pkg.name} must export its package.json`);
+
+  const expectedDependencies = Object.fromEntries(spec.deps.map((name) => [name, versionByName[name]]));
+  const actualDependencies = pkg.dependencies || {};
+  assert(
+    JSON.stringify(actualDependencies) === JSON.stringify(expectedDependencies),
+    `Package ${pkg.name} dependencies do not match expected dependency matrix`
+  );
+
+  const canonicalFiles = listCanonicalFiles(spec);
+  for (const relativeFile of canonicalFiles) {
+    const exportKey = `./${relativeFile}`;
+    assert(pkg.exports[exportKey] === `./${relativeFile}`, `Package ${pkg.name} is missing export "${exportKey}"`);
+    assert(exists(`${spec.dir}/${relativeFile}`), `Package ${pkg.name} export target does not exist: ${relativeFile}`);
+    checkedFiles += 1;
+  }
+
+  for (const [exportKey, exportTarget] of Object.entries(pkg.exports)) {
+    assert(typeof exportTarget === "string", `Package ${pkg.name} export ${exportKey} must map to a string target`);
+    if (typeof exportTarget !== "string") {
+      continue;
+    }
+    assert(exportTarget.startsWith("./"), `Package ${pkg.name} export ${exportKey} must stay within the package`);
+    assert(exists(path.posix.join(spec.dir, exportTarget.slice(2))), `Package ${pkg.name} export target is missing: ${exportTarget}`);
+  }
+}
+
+const fixturesManifest = readJson("templates/fixtures.manifest.json");
+const fixturePaths = fixturesManifest.fixtures.map((fixture) => fixture.path.replace(/^\.\//, "")).sort();
+const expectedFixturePaths = listCanonicalFiles(specs.find((spec) => spec.name === "@agreements-standard/fixtures")).sort();
+assert(
+  JSON.stringify(fixturePaths) === JSON.stringify(expectedFixturePaths),
+  "templates/fixtures.manifest.json does not match the canonical fixtures package exports"
+);
+
+if (errors.length > 0) {
+  console.error("Module verification failed:");
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Verified ${specs.length} workspace modules and ${checkedFiles} exported canonical files.`);

--- a/scripts/verify-modules.mjs
+++ b/scripts/verify-modules.mjs
@@ -7,7 +7,7 @@ const rootDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const specs = [
   {
     dir: "schemas/core",
-    name: "@cns/agreements-core",
+    name: "@cns-labs/agreements-core",
     version: "1.1.0-draft.0",
     primary: "agreement.schema.json",
     mode: "schema",
@@ -15,77 +15,77 @@ const specs = [
   },
   {
     dir: "schemas/profiles/evm",
-    name: "@cns/agreements-profile-evm",
+    name: "@cns-labs/agreements-profile-evm",
     version: "1.0.0-draft.0",
     primary: "agreement.schema.json",
     mode: "schema",
-    deps: ["@cns/agreements-core"]
+    deps: ["@cns-labs/agreements-core"]
   },
   {
     dir: "schemas/profiles/vc",
-    name: "@cns/agreements-profile-vc",
+    name: "@cns-labs/agreements-profile-vc",
     version: "1.0.0-draft.0",
     primary: "agreement-envelope.schema.json",
     mode: "schema",
-    deps: ["@cns/agreements-core"]
+    deps: ["@cns-labs/agreements-core"]
   },
   {
     dir: "schemas/profiles/eip712",
-    name: "@cns/agreements-profile-eip712",
+    name: "@cns-labs/agreements-profile-eip712",
     version: "1.0.0-draft.0",
     primary: "agreement.schema.json",
     mode: "schema",
-    deps: ["@cns/agreements-core"]
+    deps: ["@cns-labs/agreements-core"]
   },
   {
     dir: "schemas/compositions/evm-eip712",
-    name: "@cns/agreements-composition-evm-eip712",
+    name: "@cns-labs/agreements-composition-evm-eip712",
     version: "1.0.0-draft.0",
     primary: "agreement.schema.json",
     mode: "schema",
     deps: [
-      "@cns/agreements-core",
-      "@cns/agreements-profile-evm",
-      "@cns/agreements-profile-eip712"
+      "@cns-labs/agreements-core",
+      "@cns-labs/agreements-profile-evm",
+      "@cns-labs/agreements-profile-eip712"
     ]
   },
   {
     dir: "schemas/compositions/vc-eip712",
-    name: "@cns/agreements-composition-vc-eip712",
+    name: "@cns-labs/agreements-composition-vc-eip712",
     version: "1.0.0-draft.0",
     primary: "agreement-envelope.schema.json",
     mode: "schema",
     deps: [
-      "@cns/agreements-core",
-      "@cns/agreements-profile-vc",
-      "@cns/agreements-profile-eip712"
+      "@cns-labs/agreements-core",
+      "@cns-labs/agreements-profile-vc",
+      "@cns-labs/agreements-profile-eip712"
     ]
   },
   {
     dir: "schemas/compositions/evm-vc-eip712",
-    name: "@cns/agreements-composition-evm-vc-eip712",
+    name: "@cns-labs/agreements-composition-evm-vc-eip712",
     version: "1.0.0-draft.0",
     primary: "agreement-envelope.schema.json",
     mode: "schema",
     deps: [
-      "@cns/agreements-composition-evm-eip712",
-      "@cns/agreements-composition-vc-eip712"
+      "@cns-labs/agreements-composition-evm-eip712",
+      "@cns-labs/agreements-composition-vc-eip712"
     ]
   },
   {
     dir: "templates",
-    name: "@cns/agreements-fixtures",
+    name: "@cns-labs/agreements-fixtures",
     version: "1.0.0-draft.0",
     primary: "fixtures.manifest.json",
     mode: "fixtures",
     deps: [
-      "@cns/agreements-core",
-      "@cns/agreements-profile-evm",
-      "@cns/agreements-profile-vc",
-      "@cns/agreements-profile-eip712",
-      "@cns/agreements-composition-evm-eip712",
-      "@cns/agreements-composition-vc-eip712",
-      "@cns/agreements-composition-evm-vc-eip712"
+      "@cns-labs/agreements-core",
+      "@cns-labs/agreements-profile-evm",
+      "@cns-labs/agreements-profile-vc",
+      "@cns-labs/agreements-profile-eip712",
+      "@cns-labs/agreements-composition-evm-eip712",
+      "@cns-labs/agreements-composition-vc-eip712",
+      "@cns-labs/agreements-composition-evm-vc-eip712"
     ]
   }
 ];
@@ -196,7 +196,7 @@ for (const spec of specs) {
 
 const fixturesManifest = readJson("templates/fixtures.manifest.json");
 const fixturePaths = fixturesManifest.fixtures.map((fixture) => fixture.path.replace(/^\.\//, "")).sort();
-const expectedFixturePaths = listCanonicalFiles(specs.find((spec) => spec.name === "@cns/agreements-fixtures")).sort();
+const expectedFixturePaths = listCanonicalFiles(specs.find((spec) => spec.name === "@cns-labs/agreements-fixtures")).sort();
 assert(
   JSON.stringify(fixturePaths) === JSON.stringify(expectedFixturePaths),
   "templates/fixtures.manifest.json does not match the canonical fixtures package exports"

--- a/templates/README.md
+++ b/templates/README.md
@@ -6,6 +6,8 @@ Canonical example documents are organized into:
 - `profiles/` for single-profile examples
 - `compositions/` for multi-profile examples
 
+The canonical examples are also exposed as the `@agreements-standard/fixtures` workspace package, with [fixtures.manifest.json](./fixtures.manifest.json) as the package root export.
+
 Current canonical examples:
 
 - [core/consulting-agreement.core.json](./core/consulting-agreement.core.json)

--- a/templates/README.md
+++ b/templates/README.md
@@ -6,7 +6,7 @@ Canonical example documents are organized into:
 - `profiles/` for single-profile examples
 - `compositions/` for multi-profile examples
 
-The canonical examples are also exposed as the `@agreements-standard/fixtures` workspace package, with [fixtures.manifest.json](./fixtures.manifest.json) as the package root export.
+The canonical examples are also exposed as the `@cns/agreements-fixtures` workspace package, with [fixtures.manifest.json](./fixtures.manifest.json) as the package root export.
 
 Current canonical examples:
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,28 @@
+# Templates
+
+Canonical example documents are organized into:
+
+- `core/` for core-only agreements
+- `profiles/` for single-profile examples
+- `compositions/` for multi-profile examples
+
+Current canonical examples:
+
+- [core/consulting-agreement.core.json](./core/consulting-agreement.core.json)
+- [profiles/evm/grant-agreement.evm.json](./profiles/evm/grant-agreement.evm.json)
+- [profiles/evm/grant-agreement.evm.mdast.json](./profiles/evm/grant-agreement.evm.mdast.json)
+- [profiles/vc/consulting-agreement.vc.json](./profiles/vc/consulting-agreement.vc.json)
+- [compositions/evm-eip712/grant-agreement.eip712.json](./compositions/evm-eip712/grant-agreement.eip712.json)
+- [compositions/vc-eip712/consulting-agreement.vc-eip712.json](./compositions/vc-eip712/consulting-agreement.vc-eip712.json)
+- [compositions/evm-vc-eip712/grant-agreement.vc-eip712.json](./compositions/evm-vc-eip712/grant-agreement.vc-eip712.json)
+
+Legacy pre-IP-005 examples are still present at the root of this directory:
+
+- `grant-agreement.json`
+- `grant-agreement.md.json`
+- `grant-agreement.md.dfsm.json`
+- `grant-agreement-vc-wrapped.json`
+- `grant-agreement.md`
+- `grant-agreement.md.dfsm.json.md`
+
+Those files are retained for reference and legacy compatibility only.

--- a/templates/README.md
+++ b/templates/README.md
@@ -6,7 +6,7 @@ Canonical example documents are organized into:
 - `profiles/` for single-profile examples
 - `compositions/` for multi-profile examples
 
-The canonical examples are also exposed as the `@cns/agreements-fixtures` workspace package, with [fixtures.manifest.json](./fixtures.manifest.json) as the package root export.
+The canonical examples are also exposed as the `@cns-labs/agreements-fixtures` workspace package, with [fixtures.manifest.json](./fixtures.manifest.json) as the package root export.
 
 Current canonical examples:
 

--- a/templates/compositions/evm-vc-eip712/grant-agreement.vc-eip712.json
+++ b/templates/compositions/evm-vc-eip712/grant-agreement.vc-eip712.json
@@ -1,0 +1,305 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "id": "did:example:grant-agreement-vc-eip712-1",
+  "type": ["VerifiableCredential", "AgreementCredential"],
+  "issuer": {
+    "id": "did:example:foundation-1",
+    "name": "Ecosystem Foundation"
+  },
+  "issuanceDate": "2024-03-20T12:00:00Z",
+  "expirationDate": "2025-03-20T12:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:grant-recipient-1",
+    "agreement": {
+      "standard": {
+        "id": "agreements",
+        "coreVersion": "1.1.0-draft",
+        "profiles": [
+          {
+            "id": "evm",
+            "version": "1.0.0-draft"
+          },
+          {
+            "id": "eip712",
+            "version": "1.0.0-draft"
+          }
+        ]
+      },
+      "metadata": {
+        "id": "did:example:123456789abcdefghi",
+        "templateId": "did:template:grant-agreement-v1",
+        "version": "1.0.0",
+        "createdAt": "2024-03-20T12:00:00Z",
+        "name": "Grant Agreement",
+        "author": "Ecosystem Name Foundation",
+        "description": "Standard grant agreement for ecosystem development funding"
+      },
+      "variables": [
+        {
+          "id": "effectiveDate",
+          "type": "dateTime",
+          "name": "Effective Date",
+          "description": "The date when this agreement becomes effective",
+          "value": "",
+          "validation": {
+            "required": true,
+            "message": "Effective date is required"
+          }
+        },
+        {
+          "id": "foundationName",
+          "type": "string",
+          "name": "Foundation Name",
+          "description": "Legal name of the foundation entity",
+          "value": "Ecosystem Name Foundation",
+          "validation": {
+            "required": true,
+            "minLength": 3,
+            "message": "Foundation name is required"
+          }
+        },
+        {
+          "id": "jurisdiction",
+          "type": "string",
+          "name": "Jurisdiction",
+          "description": "Legal jurisdiction under which the foundation operates",
+          "value": "Jurisdiction",
+          "validation": {
+            "required": true,
+            "message": "Jurisdiction is required"
+          }
+        },
+        {
+          "id": "foundationAddress",
+          "type": "string",
+          "semanticType": "evm/address",
+          "name": "Foundation Address",
+          "description": "Blockchain address of the foundation",
+          "value": "0x123f6e75d1BE0ee699C7Eb67594FEbC14ab3AA78",
+          "validation": {
+            "required": true,
+            "pattern": "^0x[a-fA-F0-9]{40}$",
+            "message": "Invalid D3 address format"
+          }
+        },
+        {
+          "id": "grantRecipientName",
+          "type": "string",
+          "name": "Grant Recipient Name",
+          "description": "Full name of the grant recipient",
+          "value": "",
+          "validation": {
+            "required": true,
+            "minLength": 2,
+            "message": "Grant recipient name is required"
+          }
+        },
+        {
+          "id": "grantRecipientAddress",
+          "type": "string",
+          "semanticType": "evm/address",
+          "name": "Grant Recipient Address",
+          "description": "Blockchain address of the grant recipient",
+          "value": null,
+          "validation": {
+            "required": true,
+            "pattern": "^0x[a-fA-F0-9]{40}$",
+            "message": "Invalid D3 address format"
+          }
+        },
+        {
+          "id": "ecosystemName",
+          "type": "string",
+          "name": "Ecosystem Name",
+          "description": "Name of the blockchain ecosystem",
+          "value": "Ecosystem Name",
+          "validation": {
+            "required": true,
+            "message": "Ecosystem name is required"
+          }
+        },
+        {
+          "id": "workTokenName",
+          "type": "string",
+          "name": "Work Token Name",
+          "description": "Name of the ecosystem's native token",
+          "value": "WORK",
+          "validation": {
+            "required": true,
+            "message": "Token name is required"
+          }
+        },
+        {
+          "id": "tokenAllocatorName",
+          "type": "string",
+          "name": "Token Allocator Name",
+          "description": "Name of the person designated to allocate tokens",
+          "value": "",
+          "validation": {
+            "required": true,
+            "message": "Token allocator name is required"
+          }
+        },
+        {
+          "id": "tokenAllocatorAddress",
+          "type": "string",
+          "semanticType": "evm/address",
+          "name": "Token Allocator Address",
+          "description": "Blockchain address of the token allocator",
+          "value": null,
+          "validation": {
+            "required": true,
+            "pattern": "^0x[a-fA-F0-9]{40}$",
+            "message": "Invalid D3 address format"
+          }
+        },
+        {
+          "id": "rfpNumber",
+          "type": "string",
+          "name": "RFP Number",
+          "description": "Reference number for the Request for Proposal",
+          "value": "",
+          "validation": {
+            "required": true,
+            "pattern": "^WRFP-[0-9]+$",
+            "message": "RFP number must be in format WRFP-XXX"
+          }
+        },
+        {
+          "id": "rfpLink",
+          "type": "string",
+          "name": "RFP Link",
+          "description": "URL link to the Request for Proposal document",
+          "value": "",
+          "validation": {
+            "required": true,
+            "pattern": "^https?:\\/\\/.*",
+            "message": "Must be a valid URL"
+          }
+        },
+        {
+          "id": "grantAmount",
+          "type": "number",
+          "name": "Grant Amount",
+          "description": "Amount of tokens to be granted to the recipient",
+          "value": 0,
+          "validation": {
+            "required": true,
+            "min": 1,
+            "message": "Grant amount must be greater than zero"
+          }
+        }
+      ],
+      "content": {
+        "type": "md",
+        "data": "# **Grant Agreement**\n\nThis Grant Agreement (**\"Agreement\"**) is entered into on :variable{id=\"effectiveDate\"}, (the **:variable{id=\"effectiveDate\" property=\"name\"}**), between :variable{id=\"foundationName\"}, a :variable{id=\"jurisdiction\"} foundation company (the **:variable{id=\"foundationName\" property=\"name\"}**) with D3 address :variable{id=\"foundationAddress\"}, and :variable{id=\"grantRecipientName\"}, an individual with address :variable{id=\"grantRecipientAddress\"} (**:variable{id=\"grantRecipientName\" property=\"name\"}**).\n\nThe Foundation has been established, in part, to help promote growth of the :variable{id=\"ecosystemName\"} ecosystem and seeks to award grants to promote development consistent with the collective decision making of the :variable{id=\"workTokenName\"} token (**:variable{id=\"workTokenName\"}**) holder community (the **:variable{id=\"workTokenName\"} Community**).\n\nThe Grant Recipient has been selected by the Foundation Designated Token Allocator :variable{id=\"tokenAllocatorName\"} (**:variable{id=\"tokenAllocatorName\" property=\"name\"}**) with address :variable{id=\"tokenAllocatorAddress\"} to receive a grant subject and in accordance with the terms and conditions of this Agreement.\n\nTHEREFORE, the parties agree as follows:\n\n## **1. GRANT RECIPIENT ACTIVITIES**\n\n1.1 Grants. Foundation and Grant Recipient are entering into this Agreement in connection with RFP#: :variable{id=\"rfpNumber\"}, as set forth at :variable{id=\"rfpLink\"}, which describes the specific activities to be performed by Grant Recipient (the **\"Grant\"**).\n\n1.2 Performance of Grant Recipient Activities. Grant Recipient will perform the activities described in the Grant (the **\"Grant Recipient Activities\"**) in accordance with the terms and conditions set forth in each such Grant and this Agreement and with any applicable laws.\n\n## **2. GRANT DISTRIBUTION**\n\nThe Token Allocator will pay Grant Recipient on behalf of the Foundation the amount of :variable{id=\"grantAmount\"} :variable{id=\"workTokenName\"} tokens in accordance with the terms set forth in this agreement.\n\nIN WITNESS WHEREOF, the Grant Recipient has executed this Agreement on the date first written above.\n\nName: :variable{id=\"grantRecipientName\"}"
+      },
+      "execution": {
+        "type": "dfsm",
+        "data": {
+          "states": ["AWAITING_SIGNATURES", "ACTIVE_PENDING_REVIEW", "APPROVED", "REJECTED"],
+          "inputs": {
+            "grantRecipientSignature": {
+              "id": "grantRecipientSignature",
+              "format": "eip712/typed-data-signature",
+              "schemaRef": "schemas/compositions/evm-eip712/execution/input-eip712-attestation.schema.json",
+              "displayName": "Grant Recipient Signature",
+              "description": "EIP-712 typed-data signature from the grant recipient accepting the terms of the grant agreement",
+              "constraints": {
+                "signer": "${grantRecipientAddress}",
+                "signerSemanticType": "evm/address",
+                "payload": {
+                  "isGrantRecipientApproved": true
+                }
+              }
+            },
+            "workApprovedSignature": {
+              "id": "workApprovedSignature",
+              "format": "eip712/typed-data-signature",
+              "schemaRef": "schemas/compositions/evm-eip712/execution/input-eip712-attestation.schema.json",
+              "displayName": "Work Approved Signature",
+              "description": "EIP-712 typed-data signature from the token allocator confirming that the grant work has been completed successfully",
+              "constraints": {
+                "signer": "${tokenAllocatorAddress}",
+                "signerSemanticType": "evm/address",
+                "payload": {
+                  "isApproved": true
+                }
+              }
+            },
+            "workRejectedSignature": {
+              "id": "workRejectedSignature",
+              "format": "eip712/typed-data-signature",
+              "schemaRef": "schemas/compositions/evm-eip712/execution/input-eip712-attestation.schema.json",
+              "displayName": "Work Rejected Signature",
+              "description": "EIP-712 typed-data signature from the token allocator confirming that the grant work has been rejected",
+              "constraints": {
+                "signer": "${tokenAllocatorAddress}",
+                "signerSemanticType": "evm/address",
+                "payload": {
+                  "isApproved": false
+                }
+              }
+            }
+          },
+          "transitions": [
+            {
+              "from": "AWAITING_SIGNATURES",
+              "to": "ACTIVE_PENDING_REVIEW",
+              "conditions": [
+                {
+                  "type": "isValid",
+                  "inputs": ["grantRecipientSignature"]
+                }
+              ]
+            },
+            {
+              "from": "ACTIVE_PENDING_REVIEW",
+              "to": "APPROVED",
+              "conditions": [
+                {
+                  "type": "isValid",
+                  "inputs": ["workApprovedSignature"]
+                }
+              ]
+            },
+            {
+              "from": "ACTIVE_PENDING_REVIEW",
+              "to": "REJECTED",
+              "conditions": [
+                {
+                  "type": "isValid",
+                  "inputs": ["workRejectedSignature"]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "proof": {
+    "type": "EthereumEip712Signature2021",
+    "created": "2024-03-20T12:00:00Z",
+    "proofPurpose": "contractAgreement",
+    "verificationMethod": "did:example:foundation-1#key-1",
+    "eip712": {
+      "domain": {
+        "name": "Agreements Protocol",
+        "version": "1.0",
+        "chainId": 1,
+        "verifyingContract": "0x1234567890123456789012345678901234567890"
+      },
+      "types": {
+        "AgreementCredential": [
+          { "name": "id", "type": "string" },
+          { "name": "issuer", "type": "string" }
+        ]
+      },
+      "primaryType": "AgreementCredential"
+    },
+    "proofValue": "0x1234567890abcdef1234567890abcdef"
+  }
+}

--- a/templates/compositions/vc-eip712/consulting-agreement.vc-eip712.json
+++ b/templates/compositions/vc-eip712/consulting-agreement.vc-eip712.json
@@ -1,0 +1,113 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "id": "did:example:consulting-vc-eip712-1",
+  "type": ["VerifiableCredential", "AgreementCredential"],
+  "issuer": {
+    "id": "did:example:issuer-1",
+    "name": "Example Credential Issuer"
+  },
+  "issuanceDate": "2024-03-20T12:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:subject-1",
+    "agreement": {
+      "standard": {
+        "id": "agreements",
+        "coreVersion": "1.1.0-draft",
+        "profiles": []
+      },
+      "metadata": {
+        "id": "did:example:consulting-core-1",
+        "templateId": "did:template:consulting-core-v1",
+        "version": "1.0.0",
+        "createdAt": "2024-03-20T12:00:00Z",
+        "name": "Consulting Agreement",
+        "author": "Example Author",
+        "description": "Simple consulting agreement demonstrating the core document model"
+      },
+      "variables": [
+        {
+          "id": "consultantName",
+          "type": "string",
+          "name": "Consultant Name",
+          "description": "Name of the consultant providing services",
+          "value": "Jane Doe",
+          "validation": {
+            "required": true,
+            "minLength": 1
+          }
+        },
+        {
+          "id": "clientName",
+          "type": "string",
+          "name": "Client Name",
+          "description": "Name of the client receiving the services",
+          "value": "Acme Labs",
+          "validation": {
+            "required": true,
+            "minLength": 1
+          }
+        },
+        {
+          "id": "serviceDescription",
+          "type": "string",
+          "name": "Service Description",
+          "description": "Description of the consulting services",
+          "value": "one hour of startup business advice",
+          "validation": {
+            "required": true,
+            "minLength": 5
+          }
+        },
+        {
+          "id": "feeAmount",
+          "type": "number",
+          "name": "Fee Amount",
+          "description": "Amount the client will pay for the services",
+          "value": 500,
+          "validation": {
+            "required": true,
+            "min": 1
+          }
+        },
+        {
+          "id": "currency",
+          "type": "string",
+          "name": "Currency",
+          "description": "Currency of the payment amount",
+          "value": "USD",
+          "validation": {
+            "required": true,
+            "minLength": 3,
+            "maxLength": 3
+          }
+        }
+      ],
+      "content": {
+        "type": "md",
+        "data": "# Consulting Agreement\n\nThis Consulting Agreement is entered into between :variable{id='consultantName'} and :variable{id='clientName'}.\n\n:variable{id='consultantName'} agrees to provide :variable{id='serviceDescription'}.\n\nIn exchange, :variable{id='clientName'} agrees to pay :variable{id='feeAmount'} :variable{id='currency'}.\n\nSigned by both parties on the agreed effective date."
+      }
+    }
+  },
+  "proof": {
+    "type": "EthereumEip712Signature2021",
+    "created": "2024-03-20T12:00:00Z",
+    "proofPurpose": "assertionMethod",
+    "verificationMethod": "did:example:issuer-1#key-1",
+    "eip712": {
+      "domain": {
+        "name": "Agreements Protocol",
+        "version": "1.0"
+      },
+      "types": {
+        "AgreementCredential": [
+          { "name": "id", "type": "string" },
+          { "name": "issuer", "type": "string" }
+        ]
+      },
+      "primaryType": "AgreementCredential"
+    },
+    "proofValue": "0x1234567890abcdef"
+  }
+}

--- a/templates/core/consulting-agreement.core.json
+++ b/templates/core/consulting-agreement.core.json
@@ -1,0 +1,78 @@
+{
+  "standard": {
+    "id": "agreements",
+    "coreVersion": "1.1.0-draft",
+    "profiles": []
+  },
+  "metadata": {
+    "id": "did:example:consulting-core-1",
+    "templateId": "did:template:consulting-core-v1",
+    "version": "1.0.0",
+    "createdAt": "2024-03-20T12:00:00Z",
+    "name": "Consulting Agreement",
+    "author": "Example Author",
+    "description": "Simple consulting agreement demonstrating the core document model"
+  },
+  "variables": [
+    {
+      "id": "consultantName",
+      "type": "string",
+      "name": "Consultant Name",
+      "description": "Name of the consultant providing services",
+      "value": "Jane Doe",
+      "validation": {
+        "required": true,
+        "minLength": 1
+      }
+    },
+    {
+      "id": "clientName",
+      "type": "string",
+      "name": "Client Name",
+      "description": "Name of the client receiving the services",
+      "value": "Acme Labs",
+      "validation": {
+        "required": true,
+        "minLength": 1
+      }
+    },
+    {
+      "id": "serviceDescription",
+      "type": "string",
+      "name": "Service Description",
+      "description": "Description of the consulting services",
+      "value": "one hour of startup business advice",
+      "validation": {
+        "required": true,
+        "minLength": 5
+      }
+    },
+    {
+      "id": "feeAmount",
+      "type": "number",
+      "name": "Fee Amount",
+      "description": "Amount the client will pay for the services",
+      "value": 500,
+      "validation": {
+        "required": true,
+        "min": 1
+      }
+    },
+    {
+      "id": "currency",
+      "type": "string",
+      "name": "Currency",
+      "description": "Currency of the payment amount",
+      "value": "USD",
+      "validation": {
+        "required": true,
+        "minLength": 3,
+        "maxLength": 3
+      }
+    }
+  ],
+  "content": {
+    "type": "md",
+    "data": "# Consulting Agreement\n\nThis Consulting Agreement is entered into between :variable{id='consultantName'} and :variable{id='clientName'}.\n\n:variable{id='consultantName'} agrees to provide :variable{id='serviceDescription'}.\n\nIn exchange, :variable{id='clientName'} agrees to pay :variable{id='feeAmount'} :variable{id='currency'}.\n\nSigned by both parties on the agreed effective date."
+  }
+}

--- a/templates/fixtures.manifest.json
+++ b/templates/fixtures.manifest.json
@@ -4,43 +4,43 @@
     {
       "id": "core/consulting-agreement",
       "path": "./core/consulting-agreement.core.json",
-      "schemaPackage": "@agreements-standard/core",
+      "schemaPackage": "@cns/agreements-core",
       "schemaExport": "."
     },
     {
       "id": "profiles/evm/grant-agreement-md",
       "path": "./profiles/evm/grant-agreement.evm.json",
-      "schemaPackage": "@agreements-standard/profile-evm",
+      "schemaPackage": "@cns/agreements-profile-evm",
       "schemaExport": "."
     },
     {
       "id": "profiles/evm/grant-agreement-mdast",
       "path": "./profiles/evm/grant-agreement.evm.mdast.json",
-      "schemaPackage": "@agreements-standard/profile-evm",
+      "schemaPackage": "@cns/agreements-profile-evm",
       "schemaExport": "."
     },
     {
       "id": "profiles/vc/consulting-agreement-envelope",
       "path": "./profiles/vc/consulting-agreement.vc.json",
-      "schemaPackage": "@agreements-standard/profile-vc",
+      "schemaPackage": "@cns/agreements-profile-vc",
       "schemaExport": "."
     },
     {
       "id": "compositions/evm-eip712/grant-agreement",
       "path": "./compositions/evm-eip712/grant-agreement.eip712.json",
-      "schemaPackage": "@agreements-standard/composition-evm-eip712",
+      "schemaPackage": "@cns/agreements-composition-evm-eip712",
       "schemaExport": "."
     },
     {
       "id": "compositions/vc-eip712/consulting-agreement-envelope",
       "path": "./compositions/vc-eip712/consulting-agreement.vc-eip712.json",
-      "schemaPackage": "@agreements-standard/composition-vc-eip712",
+      "schemaPackage": "@cns/agreements-composition-vc-eip712",
       "schemaExport": "."
     },
     {
       "id": "compositions/evm-vc-eip712/grant-agreement-envelope",
       "path": "./compositions/evm-vc-eip712/grant-agreement.vc-eip712.json",
-      "schemaPackage": "@agreements-standard/composition-evm-vc-eip712",
+      "schemaPackage": "@cns/agreements-composition-evm-vc-eip712",
       "schemaExport": "."
     }
   ]

--- a/templates/fixtures.manifest.json
+++ b/templates/fixtures.manifest.json
@@ -1,0 +1,47 @@
+{
+  "version": "1.0.0-draft.0",
+  "fixtures": [
+    {
+      "id": "core/consulting-agreement",
+      "path": "./core/consulting-agreement.core.json",
+      "schemaPackage": "@agreements-standard/core",
+      "schemaExport": "."
+    },
+    {
+      "id": "profiles/evm/grant-agreement-md",
+      "path": "./profiles/evm/grant-agreement.evm.json",
+      "schemaPackage": "@agreements-standard/profile-evm",
+      "schemaExport": "."
+    },
+    {
+      "id": "profiles/evm/grant-agreement-mdast",
+      "path": "./profiles/evm/grant-agreement.evm.mdast.json",
+      "schemaPackage": "@agreements-standard/profile-evm",
+      "schemaExport": "."
+    },
+    {
+      "id": "profiles/vc/consulting-agreement-envelope",
+      "path": "./profiles/vc/consulting-agreement.vc.json",
+      "schemaPackage": "@agreements-standard/profile-vc",
+      "schemaExport": "."
+    },
+    {
+      "id": "compositions/evm-eip712/grant-agreement",
+      "path": "./compositions/evm-eip712/grant-agreement.eip712.json",
+      "schemaPackage": "@agreements-standard/composition-evm-eip712",
+      "schemaExport": "."
+    },
+    {
+      "id": "compositions/vc-eip712/consulting-agreement-envelope",
+      "path": "./compositions/vc-eip712/consulting-agreement.vc-eip712.json",
+      "schemaPackage": "@agreements-standard/composition-vc-eip712",
+      "schemaExport": "."
+    },
+    {
+      "id": "compositions/evm-vc-eip712/grant-agreement-envelope",
+      "path": "./compositions/evm-vc-eip712/grant-agreement.vc-eip712.json",
+      "schemaPackage": "@agreements-standard/composition-evm-vc-eip712",
+      "schemaExport": "."
+    }
+  ]
+}

--- a/templates/fixtures.manifest.json
+++ b/templates/fixtures.manifest.json
@@ -4,43 +4,43 @@
     {
       "id": "core/consulting-agreement",
       "path": "./core/consulting-agreement.core.json",
-      "schemaPackage": "@cns/agreements-core",
+      "schemaPackage": "@cns-labs/agreements-core",
       "schemaExport": "."
     },
     {
       "id": "profiles/evm/grant-agreement-md",
       "path": "./profiles/evm/grant-agreement.evm.json",
-      "schemaPackage": "@cns/agreements-profile-evm",
+      "schemaPackage": "@cns-labs/agreements-profile-evm",
       "schemaExport": "."
     },
     {
       "id": "profiles/evm/grant-agreement-mdast",
       "path": "./profiles/evm/grant-agreement.evm.mdast.json",
-      "schemaPackage": "@cns/agreements-profile-evm",
+      "schemaPackage": "@cns-labs/agreements-profile-evm",
       "schemaExport": "."
     },
     {
       "id": "profiles/vc/consulting-agreement-envelope",
       "path": "./profiles/vc/consulting-agreement.vc.json",
-      "schemaPackage": "@cns/agreements-profile-vc",
+      "schemaPackage": "@cns-labs/agreements-profile-vc",
       "schemaExport": "."
     },
     {
       "id": "compositions/evm-eip712/grant-agreement",
       "path": "./compositions/evm-eip712/grant-agreement.eip712.json",
-      "schemaPackage": "@cns/agreements-composition-evm-eip712",
+      "schemaPackage": "@cns-labs/agreements-composition-evm-eip712",
       "schemaExport": "."
     },
     {
       "id": "compositions/vc-eip712/consulting-agreement-envelope",
       "path": "./compositions/vc-eip712/consulting-agreement.vc-eip712.json",
-      "schemaPackage": "@cns/agreements-composition-vc-eip712",
+      "schemaPackage": "@cns-labs/agreements-composition-vc-eip712",
       "schemaExport": "."
     },
     {
       "id": "compositions/evm-vc-eip712/grant-agreement-envelope",
       "path": "./compositions/evm-vc-eip712/grant-agreement.vc-eip712.json",
-      "schemaPackage": "@cns/agreements-composition-evm-vc-eip712",
+      "schemaPackage": "@cns-labs/agreements-composition-evm-vc-eip712",
       "schemaExport": "."
     }
   ]

--- a/templates/package.json
+++ b/templates/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "@agreements-standard/fixtures",
+  "name": "@cns/agreements-fixtures",
   "version": "1.0.0-draft.0",
   "description": "Canonical example documents for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@agreements-standard/core": "1.1.0-draft.0",
-    "@agreements-standard/profile-evm": "1.0.0-draft.0",
-    "@agreements-standard/profile-vc": "1.0.0-draft.0",
-    "@agreements-standard/profile-eip712": "1.0.0-draft.0",
-    "@agreements-standard/composition-evm-eip712": "1.0.0-draft.0",
-    "@agreements-standard/composition-vc-eip712": "1.0.0-draft.0",
-    "@agreements-standard/composition-evm-vc-eip712": "1.0.0-draft.0"
+    "@cns/agreements-core": "1.1.0-draft.0",
+    "@cns/agreements-profile-evm": "1.0.0-draft.0",
+    "@cns/agreements-profile-vc": "1.0.0-draft.0",
+    "@cns/agreements-profile-eip712": "1.0.0-draft.0",
+    "@cns/agreements-composition-evm-eip712": "1.0.0-draft.0",
+    "@cns/agreements-composition-vc-eip712": "1.0.0-draft.0",
+    "@cns/agreements-composition-evm-vc-eip712": "1.0.0-draft.0"
   },
   "files": [
     "fixtures.manifest.json",

--- a/templates/package.json
+++ b/templates/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@agreements-standard/fixtures",
+  "version": "1.0.0-draft.0",
+  "description": "Canonical example documents for the Agreements Standard.",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@agreements-standard/core": "1.1.0-draft.0",
+    "@agreements-standard/profile-evm": "1.0.0-draft.0",
+    "@agreements-standard/profile-vc": "1.0.0-draft.0",
+    "@agreements-standard/profile-eip712": "1.0.0-draft.0",
+    "@agreements-standard/composition-evm-eip712": "1.0.0-draft.0",
+    "@agreements-standard/composition-vc-eip712": "1.0.0-draft.0",
+    "@agreements-standard/composition-evm-vc-eip712": "1.0.0-draft.0"
+  },
+  "files": [
+    "fixtures.manifest.json",
+    "core/*.json",
+    "profiles/**/*.json",
+    "compositions/**/*.json",
+    "package.json"
+  ],
+  "exports": {
+    ".": "./fixtures.manifest.json",
+    "./fixtures.manifest.json": "./fixtures.manifest.json",
+    "./core/consulting-agreement.core.json": "./core/consulting-agreement.core.json",
+    "./profiles/evm/grant-agreement.evm.json": "./profiles/evm/grant-agreement.evm.json",
+    "./profiles/evm/grant-agreement.evm.mdast.json": "./profiles/evm/grant-agreement.evm.mdast.json",
+    "./profiles/vc/consulting-agreement.vc.json": "./profiles/vc/consulting-agreement.vc.json",
+    "./compositions/evm-eip712/grant-agreement.eip712.json": "./compositions/evm-eip712/grant-agreement.eip712.json",
+    "./compositions/vc-eip712/consulting-agreement.vc-eip712.json": "./compositions/vc-eip712/consulting-agreement.vc-eip712.json",
+    "./compositions/evm-vc-eip712/grant-agreement.vc-eip712.json": "./compositions/evm-vc-eip712/grant-agreement.vc-eip712.json",
+    "./package.json": "./package.json"
+  }
+}

--- a/templates/package.json
+++ b/templates/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "@cns/agreements-fixtures",
+  "name": "@cns-labs/agreements-fixtures",
   "version": "1.0.0-draft.0",
   "description": "Canonical example documents for the Agreements Standard.",
   "license": "Apache-2.0",
   "dependencies": {
-    "@cns/agreements-core": "1.1.0-draft.0",
-    "@cns/agreements-profile-evm": "1.0.0-draft.0",
-    "@cns/agreements-profile-vc": "1.0.0-draft.0",
-    "@cns/agreements-profile-eip712": "1.0.0-draft.0",
-    "@cns/agreements-composition-evm-eip712": "1.0.0-draft.0",
-    "@cns/agreements-composition-vc-eip712": "1.0.0-draft.0",
-    "@cns/agreements-composition-evm-vc-eip712": "1.0.0-draft.0"
+    "@cns-labs/agreements-core": "1.1.0-draft.0",
+    "@cns-labs/agreements-profile-evm": "1.0.0-draft.0",
+    "@cns-labs/agreements-profile-vc": "1.0.0-draft.0",
+    "@cns-labs/agreements-profile-eip712": "1.0.0-draft.0",
+    "@cns-labs/agreements-composition-evm-eip712": "1.0.0-draft.0",
+    "@cns-labs/agreements-composition-vc-eip712": "1.0.0-draft.0",
+    "@cns-labs/agreements-composition-evm-vc-eip712": "1.0.0-draft.0"
   },
   "files": [
     "fixtures.manifest.json",

--- a/templates/profiles/evm/grant-agreement.evm.mdast.json
+++ b/templates/profiles/evm/grant-agreement.evm.mdast.json
@@ -1,0 +1,552 @@
+{
+  "standard": {
+    "id": "agreements",
+    "coreVersion": "1.1.0-draft",
+    "profiles": [
+      {
+        "id": "evm",
+        "version": "1.0.0-draft"
+      }
+    ]
+  },
+  "metadata": {
+    "id": "did:example:123456789abcdefghi",
+    "templateId": "did:template:grant-agreement-v1",
+    "version": "1.0.0",
+    "createdAt": "2024-03-20T12:00:00Z",
+    "name": "Grant Agreement",
+    "author": "Ecosystem Name Foundation",
+    "description": "Standard grant agreement for ecosystem development funding"
+  },
+  "variables": [
+    {
+      "id": "effectiveDate",
+      "type": "dateTime",
+      "name": "Effective Date",
+      "description": "The date when this agreement becomes effective",
+      "value": "",
+      "validation": {
+        "required": true,
+        "message": "Effective date is required"
+      }
+    },
+    {
+      "id": "foundationName",
+      "type": "string",
+      "name": "Foundation Name",
+      "description": "Legal name of the foundation entity",
+      "value": "Ecosystem Name Foundation",
+      "validation": {
+        "required": true,
+        "minLength": 3,
+        "message": "Foundation name is required"
+      }
+    },
+    {
+      "id": "jurisdiction",
+      "type": "string",
+      "name": "Jurisdiction",
+      "description": "Legal jurisdiction under which the foundation operates",
+      "value": "Jurisdiction",
+      "validation": {
+        "required": true,
+        "message": "Jurisdiction is required"
+      }
+    },
+    {
+      "id": "foundationAddress",
+      "type": "string",
+      "semanticType": "evm/address",
+      "name": "Foundation Address",
+      "description": "Blockchain address of the foundation",
+      "value": "0x123f6e75d1BE0ee699C7Eb67594FEbC14ab3AA78",
+      "validation": {
+        "required": true,
+        "pattern": "^0x[a-fA-F0-9]{40}$",
+        "message": "Invalid D3 address format"
+      }
+    },
+    {
+      "id": "grantRecipientName",
+      "type": "string",
+      "name": "Grant Recipient Name",
+      "description": "Full name of the grant recipient",
+      "value": "",
+      "validation": {
+        "required": true,
+        "minLength": 2,
+        "message": "Grant recipient name is required"
+      }
+    },
+    {
+      "id": "grantRecipientAddress",
+      "type": "string",
+      "semanticType": "evm/address",
+      "name": "Grant Recipient Address",
+      "description": "Blockchain address of the grant recipient",
+      "value": null,
+      "validation": {
+        "required": true,
+        "pattern": "^0x[a-fA-F0-9]{40}$",
+        "message": "Invalid D3 address format"
+      }
+    },
+    {
+      "id": "ecosystemName",
+      "type": "string",
+      "name": "Ecosystem Name",
+      "description": "Name of the blockchain ecosystem",
+      "value": "Ecosystem Name",
+      "validation": {
+        "required": true,
+        "message": "Ecosystem name is required"
+      }
+    },
+    {
+      "id": "workTokenName",
+      "type": "string",
+      "name": "Work Token Name",
+      "description": "Name of the ecosystem's native token",
+      "value": "WORK",
+      "validation": {
+        "required": true,
+        "message": "Token name is required"
+      }
+    },
+    {
+      "id": "tokenAllocatorName",
+      "type": "string",
+      "name": "Token Allocator Name",
+      "description": "Name of the person designated to allocate tokens",
+      "value": "",
+      "validation": {
+        "required": true,
+        "message": "Token allocator name is required"
+      }
+    },
+    {
+      "id": "tokenAllocatorAddress",
+      "type": "string",
+      "semanticType": "evm/address",
+      "name": "Token Allocator Address",
+      "description": "Blockchain address of the token allocator",
+      "value": null,
+      "validation": {
+        "required": true,
+        "pattern": "^0x[a-fA-F0-9]{40}$",
+        "message": "Invalid D3 address format"
+      }
+    },
+    {
+      "id": "rfpNumber",
+      "type": "string",
+      "name": "RFP Number",
+      "description": "Reference number for the Request for Proposal",
+      "value": "",
+      "validation": {
+        "required": true,
+        "pattern": "^WRFP-[0-9]+$",
+        "message": "RFP number must be in format WRFP-XXX"
+      }
+    },
+    {
+      "id": "rfpLink",
+      "type": "string",
+      "name": "RFP Link",
+      "description": "URL link to the Request for Proposal document",
+      "value": "",
+      "validation": {
+        "required": true,
+        "pattern": "^https?:\\/\\/.*",
+        "message": "Must be a valid URL"
+      }
+    },
+    {
+      "id": "grantAmount",
+      "type": "number",
+      "name": "Grant Amount",
+      "description": "Amount of tokens to be granted to the recipient",
+      "value": 0,
+      "validation": {
+        "required": true,
+        "min": 1,
+        "message": "Grant amount must be greater than zero"
+      }
+    }
+  ],
+  "content": {
+    "type": "mdast",
+    "data": {
+      "type": "root",
+      "children": [
+        {
+          "type": "heading",
+          "depth": 1,
+          "children": [
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "Grant Agreement"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "This Grant Agreement ("
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "\"Agreement\""
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": ") is entered into on "
+            },
+            {
+              "type": "variable",
+              "id": "effectiveDate"
+            },
+            {
+              "type": "text",
+              "value": ", (the "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "variable",
+                  "id": "effectiveDate",
+                  "property": "name"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": "), between "
+            },
+            {
+              "type": "variable",
+              "id": "foundationName"
+            },
+            {
+              "type": "text",
+              "value": ", a "
+            },
+            {
+              "type": "variable",
+              "id": "jurisdiction"
+            },
+            {
+              "type": "text",
+              "value": " foundation company (the "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "variable",
+                  "id": "foundationName",
+                  "property": "name"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": ") with D3 address "
+            },
+            {
+              "type": "variable",
+              "id": "foundationAddress"
+            },
+            {
+              "type": "text",
+              "value": ", and "
+            },
+            {
+              "type": "variable",
+              "id": "grantRecipientName"
+            },
+            {
+              "type": "text",
+              "value": ", an individual with address "
+            },
+            {
+              "type": "variable",
+              "id": "grantRecipientAddress"
+            },
+            {
+              "type": "text",
+              "value": " ("
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "variable",
+                  "id": "grantRecipientName",
+                  "property": "name"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": ")."
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "The Foundation has been established, in part, to help promote growth of the "
+            },
+            {
+              "type": "variable",
+              "id": "ecosystemName"
+            },
+            {
+              "type": "text",
+              "value": " ecosystem and seeks to award grants to promote development consistent with the collective decision making of the "
+            },
+            {
+              "type": "variable",
+              "id": "workTokenName"
+            },
+            {
+              "type": "text",
+              "value": " token ("
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "variable",
+                  "id": "workTokenName"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": ") holder community (the "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "variable",
+                  "id": "workTokenName"
+                },
+                {
+                  "type": "text",
+                  "value": " Community"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": ")."
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "The Grant Recipient has been selected by the Foundation Designated Token Allocator "
+            },
+            {
+              "type": "variable",
+              "id": "tokenAllocatorName"
+            },
+            {
+              "type": "text",
+              "value": " ("
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "variable",
+                  "id": "tokenAllocatorName",
+                  "property": "name"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": ") with address "
+            },
+            {
+              "type": "variable",
+              "id": "tokenAllocatorAddress"
+            },
+            {
+              "type": "text",
+              "value": " to receive a grant subject and in accordance with the terms and conditions of this Agreement."
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "THEREFORE, the parties agree as follows:"
+            }
+          ]
+        },
+        {
+          "type": "heading",
+          "depth": 2,
+          "children": [
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "1. GRANT RECIPIENT ACTIVITIES"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "1.1 Grants. Foundation and Grant Recipient are entering into this Agreement in connection with RFP#: "
+            },
+            {
+              "type": "variable",
+              "id": "rfpNumber"
+            },
+            {
+              "type": "text",
+              "value": ", as set forth at "
+            },
+            {
+              "type": "variable",
+              "id": "rfpLink"
+            },
+            {
+              "type": "text",
+              "value": ", which describes the specific activities to be performed by Grant Recipient (the "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "\"Grant\""
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": ")."
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "1.2 Performance of Grant Recipient Activities. Grant Recipient will perform the activities described in the Grant (the "
+            },
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "\"Grant Recipient Activities\""
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "value": ") in accordance with the terms and conditions set forth in each such Grant and this Agreement and with any applicable laws."
+            }
+          ]
+        },
+        {
+          "type": "heading",
+          "depth": 2,
+          "children": [
+            {
+              "type": "strong",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "2. GRANT DISTRIBUTION"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "The Token Allocator will pay Grant Recipient on behalf of the Foundation the amount of "
+            },
+            {
+              "type": "variable",
+              "id": "grantAmount"
+            },
+            {
+              "type": "text",
+              "value": " "
+            },
+            {
+              "type": "variable",
+              "id": "workTokenName"
+            },
+            {
+              "type": "text",
+              "value": " tokens in accordance with the terms set forth in this agreement."
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "IN WITNESS WHEREOF, the Grant Recipient has executed this Agreement on the date first written above."
+            }
+          ]
+        },
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Name: "
+            },
+            {
+              "type": "variable",
+              "id": "grantRecipientName"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/templates/profiles/vc/consulting-agreement.vc.json
+++ b/templates/profiles/vc/consulting-agreement.vc.json
@@ -1,0 +1,101 @@
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1"
+  ],
+  "id": "did:example:consulting-vc-1",
+  "type": ["VerifiableCredential", "AgreementCredential"],
+  "issuer": {
+    "id": "did:example:issuer-1",
+    "name": "Example Credential Issuer"
+  },
+  "issuanceDate": "2024-03-20T12:00:00Z",
+  "credentialSubject": {
+    "id": "did:example:subject-1",
+    "agreement": {
+      "standard": {
+        "id": "agreements",
+        "coreVersion": "1.1.0-draft",
+        "profiles": []
+      },
+      "metadata": {
+        "id": "did:example:consulting-core-1",
+        "templateId": "did:template:consulting-core-v1",
+        "version": "1.0.0",
+        "createdAt": "2024-03-20T12:00:00Z",
+        "name": "Consulting Agreement",
+        "author": "Example Author",
+        "description": "Simple consulting agreement demonstrating the core document model"
+      },
+      "variables": [
+        {
+          "id": "consultantName",
+          "type": "string",
+          "name": "Consultant Name",
+          "description": "Name of the consultant providing services",
+          "value": "Jane Doe",
+          "validation": {
+            "required": true,
+            "minLength": 1
+          }
+        },
+        {
+          "id": "clientName",
+          "type": "string",
+          "name": "Client Name",
+          "description": "Name of the client receiving the services",
+          "value": "Acme Labs",
+          "validation": {
+            "required": true,
+            "minLength": 1
+          }
+        },
+        {
+          "id": "serviceDescription",
+          "type": "string",
+          "name": "Service Description",
+          "description": "Description of the consulting services",
+          "value": "one hour of startup business advice",
+          "validation": {
+            "required": true,
+            "minLength": 5
+          }
+        },
+        {
+          "id": "feeAmount",
+          "type": "number",
+          "name": "Fee Amount",
+          "description": "Amount the client will pay for the services",
+          "value": 500,
+          "validation": {
+            "required": true,
+            "min": 1
+          }
+        },
+        {
+          "id": "currency",
+          "type": "string",
+          "name": "Currency",
+          "description": "Currency of the payment amount",
+          "value": "USD",
+          "validation": {
+            "required": true,
+            "minLength": 3,
+            "maxLength": 3
+          }
+        }
+      ],
+      "content": {
+        "type": "md",
+        "data": "# Consulting Agreement\n\nThis Consulting Agreement is entered into between :variable{id='consultantName'} and :variable{id='clientName'}.\n\n:variable{id='consultantName'} agrees to provide :variable{id='serviceDescription'}.\n\nIn exchange, :variable{id='clientName'} agrees to pay :variable{id='feeAmount'} :variable{id='currency'}.\n\nSigned by both parties on the agreed effective date."
+      }
+    }
+  },
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2024-03-20T12:00:00Z",
+    "proofPurpose": "assertionMethod",
+    "verificationMethod": "did:example:issuer-1#key-1",
+    "cryptosuite": "example-suite",
+    "proofValue": "zExampleProofValue"
+  }
+}


### PR DESCRIPTION
## Summary
- rewrite the top-level docs around the canonical core/profile/composition model
- add directory guides for schemas and templates
- add canonical core, vc, vc+eip712, evm+vc+eip712, and evm mdast examples

## Validation
- ran full jsonschema self-checks across schemas/core, schemas/profiles, and schemas/compositions
- validated all canonical examples, including the new evm mdast example, against their entrypoint schemas

| Package | Includes |
| --- | --- |
| `@cns-labs/agreements-core` | Chain-neutral agreement schemas: base agreement document, metadata, variables, content, MDAST, DFSM execution model, and generic execution input schemas. |
| `@cns-labs/agreements-profile-evm` | EVM-only semantics layered on core: EVM agreement schema, EVM address semantic schema, and EVM transaction receipt input schema. |
| `@cns-labs/agreements-profile-vc` | VC-only envelope semantics layered on core: agreement VC envelope schema and VC execution input schema. |
| `@cns-labs/agreements-profile-eip712` | EIP-712 proof semantics layered on core: EIP-712 agreement schema, typed-data signature input schema, and typed-data proof schema. |
| `@cns-labs/agreements-composition-evm-eip712` | Explicit composition for EVM agreements executed via EIP-712: composed agreement schema and EVM-specific EIP-712 attestation input schema. |
| `@cns-labs/agreements-composition-vc-eip712` | Explicit composition for VC envelopes using EIP-712 proofs: composed VC envelope schema. |
| `@cns-labs/agreements-composition-evm-vc-eip712` | Explicit composition for VC-wrapped EVM agreements with EIP-712 proofs: top-level composed envelope schema. |
| `@cns-labs/agreements-fixtures` | Canonical example documents and fixture manifest: core consulting agreement, EVM grant agreement in `md`, EVM grant agreement in `mdast`, VC consulting agreement envelope, EVM + EIP-712 grant agreement, VC + EIP-712 consulting agreement, and EVM + VC + EIP-712 grant agreement envelope. |